### PR TITLE
Convert all date and datetime parameters to timezone-aware ISO 8601 timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs/_build
 
 .idea
 .mypy_cache
+venv/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+0.10.0 (TBD)
++++++++++++++++++
+
+* Added more info & examples to README for taxa endpoints
+* Added `minify` option to `node_api.get_taxa_autocomplete()`
+* Convert all date and datetime parameters to timezone-aware ISO 8601 timestamps
+
 0.9.1 (2020-05-26)
 ++++++++++++++++++
 

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -3,6 +3,27 @@ INAT_BASE_URL = "https://www.inaturalist.org"
 
 THROTTLING_DELAY = 1  # In seconds, support <0 floats such as 0.1
 
+# All request parameters from both Node API and REST (Rails) API that accept date or datetime strings
+DATETIME_PARAMS = [
+    "created_after",
+    "created_d1",
+    "created_d2",
+    "created_on",
+    "d1",
+    "d2",
+    "newer_than",
+    "observation_created_d1",
+    "observation_created_d2",
+    "observed_d1",
+    "observed_d2",
+    "observed_on",
+    "older_than",
+    "on",
+    "since",
+    "updated_since",  # TODO: test if this one behaves differently in Node API vs REST API
+]
+
+
 # Taxonomic ranks from Node API Swagger spec
 RANKS = [
     "form",

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -12,9 +12,7 @@ from pyinaturalist.exceptions import ObservationNotFound
 from pyinaturalist.helpers import (
     merge_two_dicts,
     get_user_agent,
-    convert_bool_params,
-    convert_list_params,
-    strip_empty_params,
+    preprocess_request_params,
 )
 
 PER_PAGE_RESULTS = 30  # Paginated queries: how many records do we ask per page?
@@ -32,9 +30,7 @@ def make_inaturalist_api_get_call(
     kwargs are passed to requests.request
     Returns a requests.Response object
     """
-    params = convert_bool_params(params)
-    params = convert_list_params(params)
-    params = strip_empty_params(params)
+    params = preprocess_request_params(params)
     headers = {"Accept": "application/json", "User-Agent": get_user_agent(user_agent)}
 
     response = requests.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ py==1.7.0
 pycparser==2.19
 Pygments==2.2.0
 pyparsing==2.2.2
+python-dateutil==2.8.1
 pytz==2018.5
 readme-renderer==22.0
 requests==2.20.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=["pyinaturalist"],
     package_dir={"pyinaturalist": "pyinaturalist"},
     include_package_data=True,
-    install_requires=["requests>=2.21.0", "typing>=3.7.4"],
+    install_requires=["python-dateutil>=2.0", "requests>=2.21.0", "typing>=3.7.4"],
     extras_require={
         "dev": [
             "black",

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,18 +1,25 @@
+import pytest
+from datetime import date, datetime
+from dateutil.tz import gettz
+from unittest.mock import patch
+
 from pyinaturalist.helpers import (
+    preprocess_request_params,
     convert_bool_params,
+    convert_datetime_params,
     convert_list_params,
     strip_empty_params,
 )
 
 
 TEST_PARAMS = {
-    "parent_id": 1,
-    "rank": ["phylum", "class"],
     "is_active": False,
     "only_id": "true",
+    "preferred_place_id": [1, 2],
+    "rank": ["phylum", "class"],
     "q": "",
     "locale": None,
-    "preferred_place_id": [1, 2],
+    "parent_id": 1,
 }
 
 
@@ -20,6 +27,26 @@ def test_convert_bool_params():
     params = convert_bool_params(TEST_PARAMS)
     assert params["is_active"] == "false"
     assert params["only_id"] == "true"
+
+
+# Test some recognized date(time) formats, with and without TZ info, in date and non-date params
+@pytest.mark.parametrize(
+    "param, value, expected",
+    [
+        ("created_d1", "19951231T235959", "1995-12-31T23:59:59-08:00"),
+        ("created_d2", "2008-08-08 08:08:08Z", "2008-08-08T08:08:08+00:00"),
+        ("created_on", "2010-10-10 10:10:10-05:00", "2010-10-10T10:10:10-05:00"),
+        ("created_on", "Jan 1 2000", "2000-01-01T00:00:00-08:00"),
+        ("d1", "19970716", "1997-07-16T00:00:00-07:00"),
+        ("q", date(1954, 2, 5), "1954-02-05"),
+        ("q", datetime(1954, 2, 5), "1954-02-05T00:00:00-08:00"),
+        ("q", "not a datetime", "not a datetime"),
+    ],
+)
+@patch("pyinaturalist.helpers.tzlocal", return_value=gettz("US/Pacific"))
+def test_convert_datetime_params(tzlocal, param, value, expected):
+    converted = convert_datetime_params({param: value})
+    assert converted[param] == expected
 
 
 def test_convert_list_params():


### PR DESCRIPTION
Completes Issue #19 

Adds `python-dateutil` as a dependency. Using the [dateutil parser](https://dateutil.readthedocs.io/en/stable/parser.html) will add support for pretty much all common timestamp formats (and a lot of obscure ones too).

To reliably determine which parameters need to be converted (if they're already strings but in a non-ISO format), I am adding a hardcoded list of all date and datetime request parameters from both the Node API and REST API.

- [x] Convert `date` or `datetime` params to ISO format
- [x] List all request params that accept date or datetime objects
- [x] Parse and convert date/time strings of other formats into ISO format
- [x] Add local timezone offset (`±xx:xx`) from local system time, if not already provided
- [x] Confirm working with manual tests
- [x] Add unit tests
- [x] Update release notes