### PR TITLE
Update REST API module with param conversion + unit tests

### DIFF
--- a/pyinaturalist/api_requests.py
+++ b/pyinaturalist/api_requests.py
@@ -1,0 +1,55 @@
+# Some common functions for HTTP requests used by both the Node and REST API modules
+import requests
+from typing import Dict
+
+import pyinaturalist
+from pyinaturalist.helpers import preprocess_request_params
+
+
+def delete(url: str, **kwargs) -> requests.Response:
+    """Wrapper around :py:func:`requests.delete` that supports dry-run mode"""
+    return request("DELETE", url, **kwargs)
+
+
+def get(url: str, **kwargs) -> requests.Response:
+    """Wrapper around :py:func:`requests.get` that supports dry-run mode"""
+    return request("GET", url, **kwargs)
+
+
+def post(url: str, **kwargs) -> requests.Response:
+    """Wrapper around :py:func:`requests.post` that supports dry-run mode"""
+    return request("POST", url, **kwargs)
+
+
+def put(url: str, **kwargs) -> requests.Response:
+    """Wrapper around :py:func:`requests.put` that supports dry-run mode"""
+    return request("PUT", url, **kwargs)
+
+
+def request(
+    method: str,
+    url: str,
+    access_token: str = None,
+    user_agent: str = None,
+    params: Dict = None,
+    headers: Dict = None,
+    **kwargs
+) -> requests.Response:
+    """Wrapper around :py:func:`requests.request` that supports dry-run mode and
+    adds appropriate headers.
+
+    :param method: HTTP method
+    :param url: Request URL
+    :param access_token: access_token: the access token, as returned by :func:`get_access_token()`
+    :param user_agent: a user-agent string that will be passed to iNaturalist
+
+    """
+    # Set user agent and authentication headers, if specified
+    headers = headers or {}
+    headers["Accept"] = "application/json"
+    headers["User-Agent"] = user_agent or pyinaturalist.user_agent
+    if access_token:
+        headers["Authorization"] = "Bearer %s" % access_token
+    params = preprocess_request_params(params)
+
+    return requests.request(method, url, params=params, headers=headers, **kwargs)

--- a/pyinaturalist/helpers.py
+++ b/pyinaturalist/helpers.py
@@ -25,6 +25,15 @@ def preprocess_request_params(params: Dict[str, Any]) -> Dict[str, Any]:
     return params
 
 
+def is_int(value: Any) -> bool:
+    """Determine if a value is a valid integer"""
+    try:
+        int(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
 def convert_bool_params(params: Dict[str, Any]) -> Dict[str, Any]:
     """Convert any boolean request parameters to javascript-style boolean strings"""
     for k, v in params.items():

--- a/pyinaturalist/helpers.py
+++ b/pyinaturalist/helpers.py
@@ -4,7 +4,6 @@ from typing import Dict, Any
 from dateutil.parser import parse as parse_timestamp
 from dateutil.tz import tzlocal
 from pyinaturalist.constants import DATETIME_PARAMS
-import pyinaturalist
 
 
 # For Python < 3.5 compatibility
@@ -12,14 +11,6 @@ def merge_two_dicts(x, y):
     z = x.copy()
     z.update(y)
     return z
-
-
-def get_user_agent(user_agent: str = None) -> str:
-    """Return the user agent to be used."""
-    if user_agent is not None:  # If we explicitly provide one, use it
-        return user_agent
-    else:  # Otherwise we have a global one in __init__.py (configurable, with sensible defaults)
-        return pyinaturalist.user_agent
 
 
 def preprocess_request_params(params: Dict[str, Any]) -> Dict[str, Any]:

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -146,7 +146,7 @@ def get_taxa(
     :returns: A list of dicts containing taxa results
     """
     if min_rank or max_rank:
-        params["rank"] = get_rank_range(min_rank, max_rank)
+        params["rank"] = _get_rank_range(min_rank, max_rank)
     r = make_inaturalist_api_get_call("taxa", params, user_agent=user_agent)
     r.raise_for_status()
     return r.json()
@@ -200,7 +200,7 @@ def format_taxon(taxon: Dict) -> str:
     )
 
 
-def get_rank_range(min_rank: str = None, max_rank: str = None) -> List[str]:
+def _get_rank_range(min_rank: str = None, max_rank: str = None) -> List[str]:
     """ Translate min and/or max rank into a list of ranks """
     min_rank_index = _get_rank_index(min_rank) if min_rank else 0
     max_rank_index = _get_rank_index(max_rank) + 1 if max_rank else len(RANKS)

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin
 
 from pyinaturalist.constants import THROTTLING_DELAY, INAT_NODE_API_BASE_URL, RANKS
 from pyinaturalist.exceptions import ObservationNotFound
-from pyinaturalist.helpers import merge_two_dicts
+from pyinaturalist.helpers import is_int, merge_two_dicts
 from pyinaturalist.api_requests import get
 
 PER_PAGE_RESULTS = 30  # Paginated queries: how many records do we ask per page?
@@ -110,7 +110,7 @@ def get_taxa_by_id(taxon_id: int, user_agent: str = None) -> Dict[str, Any]:
 
     :returns: A list of dicts containing taxa results
     """
-    if not isinstance(taxon_id, int):
+    if not is_int(taxon_id):
         raise ValueError("Please specify a single integer for the taxon ID")
     r = make_inaturalist_api_get_call(
         "taxa/{}".format(taxon_id), {}, user_agent=user_agent

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -9,11 +9,8 @@ from urllib.parse import urljoin
 
 from pyinaturalist.constants import THROTTLING_DELAY, INAT_NODE_API_BASE_URL, RANKS
 from pyinaturalist.exceptions import ObservationNotFound
-from pyinaturalist.helpers import (
-    merge_two_dicts,
-    get_user_agent,
-    preprocess_request_params,
-)
+from pyinaturalist.helpers import merge_two_dicts
+from pyinaturalist.api_requests import get
 
 PER_PAGE_RESULTS = 30  # Paginated queries: how many records do we ask per page?
 
@@ -30,11 +27,11 @@ def make_inaturalist_api_get_call(
     kwargs are passed to requests.request
     Returns a requests.Response object
     """
-    params = preprocess_request_params(params)
-    headers = {"Accept": "application/json", "User-Agent": get_user_agent(user_agent)}
-
-    response = requests.get(
-        urljoin(INAT_NODE_API_BASE_URL, endpoint), params, headers=headers, **kwargs
+    response = get(
+        urljoin(INAT_NODE_API_BASE_URL, endpoint),
+        params=params,
+        user_agent=user_agent,
+        **kwargs
     )
     return response
 

--- a/pyinaturalist/rest_api.py
+++ b/pyinaturalist/rest_api.py
@@ -1,7 +1,7 @@
 # Code used to access the (read/write, but slow) Rails based API of iNaturalist
 # See: https://www.inaturalist.org/pages/api+reference
 from time import sleep
-from typing import Dict, Any, List, BinaryIO, Union  # noqa: F401
+from typing import Dict, Any, List, BinaryIO, Union
 
 from pyinaturalist.constants import THROTTLING_DELAY, INAT_BASE_URL
 from pyinaturalist.exceptions import AuthenticationError, ObservationNotFound

--- a/pyinaturalist/rest_api.py
+++ b/pyinaturalist/rest_api.py
@@ -3,20 +3,9 @@
 from time import sleep
 from typing import Dict, Any, List, BinaryIO, Union  # noqa: F401
 
-import requests
-
 from pyinaturalist.constants import THROTTLING_DELAY, INAT_BASE_URL
 from pyinaturalist.exceptions import AuthenticationError, ObservationNotFound
-from pyinaturalist.helpers import get_user_agent
-
-
-def _build_headers(access_token: str = None, user_agent: str = None) -> Dict[str, str]:
-    headers = {"User-Agent": get_user_agent(user_agent)}
-
-    if access_token:
-        headers["Authorization"] = "Bearer %s" % access_token
-
-    return headers
+from pyinaturalist.api_requests import delete, get, post, put
 
 
 def get_observation_fields(
@@ -33,10 +22,10 @@ def get_observation_fields(
     """
     payload = {"q": search_query, "page": page}  # type: Dict[str, Union[int, str]]
 
-    response = requests.get(
+    response = get(
         "{base_url}/observation_fields.json".format(base_url=INAT_BASE_URL),
         params=payload,
-        headers=_build_headers(user_agent=user_agent),
+        user_agent=user_agent,
     )
     return response.json()
 
@@ -112,11 +101,12 @@ def put_observation_field_values(
         }
     }
 
-    response = requests.put(
+    response = put(
         "{base_url}/observation_field_values/{id}".format(
             base_url=INAT_BASE_URL, id=observation_field_id
         ),
-        headers=_build_headers(access_token=access_token, user_agent=user_agent),
+        access_token=access_token,
+        user_agent=user_agent,
         json=payload,
     )
 
@@ -148,10 +138,10 @@ def get_access_token(
         "password": password,
     }
 
-    response = requests.post(
+    response = post(
         "{base_url}/oauth/token".format(base_url=INAT_BASE_URL),
-        payload,
-        headers=_build_headers(user_agent=user_agent),
+        json=payload,
+        user_agent=user_agent,
     )
     try:
         return response.json()["access_token"]
@@ -175,9 +165,10 @@ def add_photo_to_observation(
     data = {"observation_photo[observation_id]": observation_id}
     file_data = {"file": file_object}
 
-    response = requests.post(
+    response = post(
         url="{base_url}/observation_photos".format(base_url=INAT_BASE_URL),
-        headers=_build_headers(access_token=access_token, user_agent=user_agent),
+        access_token=access_token,
+        user_agent=user_agent,
         data=data,
         files=file_data,
     )
@@ -210,10 +201,11 @@ def create_observations(
     TODO investigate: according to the doc, we should be able to pass multiple observations (in an array, and in
     renaming observation to observations, but as far as I saw they are not created (while a status of 200 is returned)
     """
-    response = requests.post(
+    response = post(
         url="{base_url}/observations.json".format(base_url=INAT_BASE_URL),
         json=params,
-        headers=_build_headers(access_token=access_token, user_agent=user_agent),
+        access_token=access_token,
+        user_agent=user_agent,
     )
     response.raise_for_status()
     return response.json()
@@ -238,12 +230,13 @@ def update_observation(
             doesn't exists or belongs to another user (as of November 2018).
     """
 
-    response = requests.put(
+    response = put(
         url="{base_url}/observations/{id}.json".format(
             base_url=INAT_BASE_URL, id=observation_id
         ),
         json=params,
-        headers=_build_headers(access_token=access_token, user_agent=user_agent),
+        access_token=access_token,
+        user_agent=user_agent,
     )
     response.raise_for_status()
     return response.json()
@@ -266,15 +259,13 @@ def delete_observation(
     :raise: ObservationNotFound if the requested observation doesn't exists, requests.HTTPError (403) if the
             observation belongs to another user
     """
-
-    headers = _build_headers(access_token=access_token, user_agent=user_agent)
-    headers["Content-type"] = "application/json"
-
-    response = requests.delete(
+    response = delete(
         url="{base_url}/observations/{id}.json".format(
             base_url=INAT_BASE_URL, id=observation_id
         ),
-        headers=headers,
+        access_token=access_token,
+        user_agent=user_agent,
+        headers={"Content-type": "application/json"},
     )
     if response.status_code == 404:
         raise ObservationNotFound

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,52 @@
+"""
+Shared unit test-related utilities.
+Pytest will also automatically pick up any fixtures defined here.
+"""
+import json
+import os
+import re
+from inspect import getmembers, isfunction, signature, Parameter
+from unittest.mock import MagicMock
+
+HTTP_FUNC_PATTERN = re.compile(r"(get|put|post|delete)_.+")
+
+
+def get_module_functions(module):
+    """ Get all functions belonging to a module (excluding imports) """
+    return {
+        name: member
+        for name, member in getmembers(module)
+        if isfunction(member) and member.__module__ == module.__name__
+    }
+
+
+def get_module_http_functions(module):
+    """ Get all functions belonging to a module and prefixed with an HTTP method """
+    return {
+        name: func
+        for name, func in getmembers(module)
+        if HTTP_FUNC_PATTERN.match(name.lower())
+    }
+
+
+def get_mock_args_for_signature(func):
+    """ Automagically get a list of mock objects corresponding to the required arguments
+    in a function's signature. Using ``inspect.Signature``, 'Required' is defined by:
+    1. positional and 2. no default
+    """
+    required_args = [
+        p
+        for p in signature(func).parameters.values()
+        if p.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+        and p.default is Parameter.empty
+    ]
+    return [MagicMock()] * len(required_args)
+
+
+def _sample_data_path(filename):
+    return os.path.join(os.path.dirname(__file__), "sample_data", filename)
+
+
+def load_sample_json(filename):
+    with open(_sample_data_path(filename), encoding="utf-8") as fh:
+        return json.load(fh)

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -27,7 +27,7 @@ def test_http_methods(mock_request, function, http_method):
         ),
         (
             {"access_token": "token"},
-            {"Accept": "application/json", "User-Agent": pyinaturalist.user_agent, "Authorization": "Bearer token",},
+            {"Accept": "application/json", "User-Agent": pyinaturalist.user_agent, "Authorization": "Bearer token"},
         ),
     ],
 )

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import patch
+
+import pyinaturalist
+from pyinaturalist.api_requests import delete, get, post, put, request
+
+
+# Just test that the wrapper methods call requests.request with the appropriate HTTP method
+@pytest.mark.parametrize(
+    "function, http_method",
+    [(delete, "DELETE"), (get, "GET"), (post, "POST"), (put, "PUT")],
+)
+@patch("pyinaturalist.api_requests.request")
+def test_http_methods(mock_request, function, http_method):
+    function("https://url", param="value")
+    mock_request.assert_called_with(http_method, "https://url", param="value")
+
+
+# Test that the requests() wrapper passes along expected headers; just tests kwargs, not mock response
+@pytest.mark.parametrize(
+    "input_kwargs, expected_headers",
+    [
+        ({}, {"Accept": "application/json", "User-Agent": pyinaturalist.user_agent}),
+        (
+            {"user_agent": "CustomUA"},
+            {"Accept": "application/json", "User-Agent": "CustomUA"},
+        ),
+        (
+            {"access_token": "token"},
+            {"Accept": "application/json", "User-Agent": pyinaturalist.user_agent, "Authorization": "Bearer token",},
+        ),
+    ],
+)
+@patch("pyinaturalist.api_requests.requests.request")
+def test_request_headers(mock_request, input_kwargs, expected_headers):
+    request("GET", "https://url", **input_kwargs)
+    request_kwargs = mock_request.call_args[1]
+    assert request_kwargs["headers"] == expected_headers

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -85,7 +85,6 @@ def test_preprocess_request_params(mock_bool, mock_datetime, mock_list, mock_str
     "http_function", get_module_http_functions(pyinaturalist.node_api).values()
 )
 @patch("pyinaturalist.node_api._get_rank_range")
-@patch("pyinaturalist.node_api.isinstance")
 @patch("pyinaturalist.node_api.merge_two_dicts")
 @patch("pyinaturalist.api_requests.preprocess_request_params")
 @patch("pyinaturalist.api_requests.requests.request")
@@ -94,13 +93,12 @@ def test_all_node_requests_use_param_conversion(
     preprocess_request_params,
     merge_two_dicts,
     get_rank_range,
-    isinstance,
     http_function,
 ):
     request().json.return_value = {"total_results": 1, "results": [{}]}
     mock_args = get_mock_args_for_signature(http_function)
     http_function(*mock_args)
-    preprocess_request_params.assert_called()
+    assert preprocess_request_params.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -124,4 +122,4 @@ def test_all_rest_requests_use_param_conversion(
 
     mock_args = get_mock_args_for_signature(http_function)
     http_function(*mock_args)
-    preprocess_request_params.assert_called()
+    assert preprocess_request_params.call_count == 1

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -29,6 +29,20 @@ def test_convert_bool_params():
     assert params["only_id"] == "true"
 
 
+# Test both int and string lists
+def test_convert_list_params():
+    params = convert_list_params(TEST_PARAMS)
+    assert params["preferred_place_id"] == "1,2"
+    assert params["rank"] == "phylum,class"
+
+
+def test_strip_empty_params():
+    params = strip_empty_params(TEST_PARAMS)
+    assert len(params) == 5
+    assert "q" not in params and "locale" not in params
+    assert "is_active" in params and "only_id" in params
+
+
 # Test some recognized date(time) formats, with and without TZ info, in date and non-date params
 @pytest.mark.parametrize(
     "param, value, expected",
@@ -49,14 +63,13 @@ def test_convert_datetime_params(tzlocal, param, value, expected):
     assert converted[param] == expected
 
 
-def test_convert_list_params():
-    params = convert_list_params(TEST_PARAMS)
-    assert params["preferred_place_id"] == "1,2"
-    assert params["rank"] == "phylum,class"
-
-
-def test_strip_empty_params():
-    params = strip_empty_params(TEST_PARAMS)
-    assert len(params) == 5
-    assert "q" not in params and "locale" not in params
-    assert "is_active" in params and "only_id" in params
+# This is just here so that tests will fail if one of the conversion steps is removed
+@patch("pyinaturalist.helpers.convert_bool_params")
+@patch("pyinaturalist.helpers.convert_datetime_params")
+@patch("pyinaturalist.helpers.convert_list_params")
+@patch("pyinaturalist.helpers.strip_empty_params")
+def test_preprocess_request_params(mock_bool, mock_datetime, mock_list, mock_strip):
+    preprocess_request_params({"id": 1})
+    assert all(
+        [mock_bool.called, mock_datetime.called, mock_list.called, mock_strip.called]
+    )

--- a/test/test_pyinaturalist.py
+++ b/test/test_pyinaturalist.py
@@ -121,11 +121,11 @@ class TestNodeApi(object):
         )
 
     # This is just a spot test of a case in which boolean params should be converted
-    @patch("pyinaturalist.node_api.requests")
-    def test_get_taxa_by_name_and_is_active(self, requests):
+    @patch("pyinaturalist.api_requests.requests.request")
+    def test_get_taxa_by_name_and_is_active(self, request):
         get_taxa(q="Lixus bardanae", is_active=False)
-        request_args = requests.get.call_args[0]
-        assert request_args[1] == {"q": "Lixus bardanae", "is_active": "false"}
+        request_kwargs = request.call_args[1]
+        assert request_kwargs["params"] == {"q": "Lixus bardanae", "is_active": "false"}
 
     def test_get_taxa_by_id(self, requests_mock):
         taxon_id = 70118
@@ -193,12 +193,12 @@ class TestNodeApi(object):
     # This test just ensures that all GET requests call preprocess_request_params() at some point
     @patch("pyinaturalist.node_api.get_rank_range")
     @patch("pyinaturalist.node_api.merge_two_dicts")
-    @patch("pyinaturalist.node_api.preprocess_request_params")
-    @patch("pyinaturalist.node_api.requests")
+    @patch("pyinaturalist.api_requests.preprocess_request_params")
+    @patch("pyinaturalist.api_requests.requests.request")
     def test_all_get_requests_use_param_conversion(
-        self, requests, preprocess_request_params, merge_two_dicts, get_rank_range
+        self, request, preprocess_request_params, merge_two_dicts, get_rank_range
     ):
-        requests.get().json.return_value = {"total_results": 1, "results": [{}]}
+        request().json.return_value = {"total_results": 1, "results": [{}]}
 
         # This dynamically gets all functions named pyinaturalist.node_api.get_*
         http_get_functions = [

--- a/test/test_pyinaturalist.py
+++ b/test/test_pyinaturalist.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
-import requests_mock
 from requests import HTTPError
 from urllib.parse import urlencode, urljoin
 
@@ -171,12 +170,10 @@ class TestNodeApi(object):
 
 
 class TestRestApi(object):
-    @requests_mock.Mocker(kw="mock")
-    def test_get_observation_fields(self, **kwargs):
+    def test_get_observation_fields(self, requests_mock):
         """ get_observation_fields() work as expected (basic use)"""
-        mock = kwargs["mock"]
 
-        mock.get(
+        requests_mock.get(
             "https://www.inaturalist.org/observation_fields.json?q=sex&page=2",
             json=PAGE_2_JSON_RESPONSE,
             status_code=200,
@@ -185,25 +182,23 @@ class TestRestApi(object):
         obs_fields = get_observation_fields(search_query="sex", page=2)
         assert obs_fields == PAGE_2_JSON_RESPONSE
 
-    @requests_mock.Mocker(kw="mock")
-    def test_get_all_observation_fields(self, **kwargs):
+    def test_get_all_observation_fields(self, requests_mock):
         """get_all_observation_fields() is able to paginate, accepts a search query and return correct results"""
-        mock = kwargs["mock"]
 
-        mock.get(
+        requests_mock.get(
             "https://www.inaturalist.org/observation_fields.json?q=sex&page=1",
             json=PAGE_1_JSON_RESPONSE,
             status_code=200,
         )
 
-        mock.get(
+        requests_mock.get(
             "https://www.inaturalist.org/observation_fields.json?q=sex&page=2",
             json=PAGE_2_JSON_RESPONSE,
             status_code=200,
         )
 
         page_3_json_response = []
-        mock.get(
+        requests_mock.get(
             "https://www.inaturalist.org/observation_fields.json?q=sex&page=3",
             json=page_3_json_response,
             status_code=200,
@@ -212,12 +207,9 @@ class TestRestApi(object):
         all_fields = get_all_observation_fields(search_query="sex")
         assert all_fields == PAGE_1_JSON_RESPONSE + PAGE_2_JSON_RESPONSE
 
-    @requests_mock.Mocker(kw="mock")
-    def test_get_all_observation_fields_noparam(self, **kwargs):
+    def test_get_all_observation_fields_noparam(self, requests_mock):
         """get_all_observation_fields() can also be called without a search query without errors"""
-
-        mock = kwargs["mock"]
-        mock.get(
+        requests_mock.get(
             "https://www.inaturalist.org/observation_fields.json?page=1",
             json=[],
             status_code=200,
@@ -225,11 +217,9 @@ class TestRestApi(object):
 
         get_all_observation_fields()
 
-    @requests_mock.Mocker(kw="mock")
-    def test_get_access_token_fail(self, **kwargs):
+    def test_get_access_token_fail(self, requests_mock):
         """ If we provide incorrect credentials to get_access_token(), an AuthenticationError is raised"""
 
-        mock = kwargs["mock"]
         rejection_json = {
             "error": "invalid_client",
             "error_description": "Client authentication failed due to "
@@ -237,7 +227,7 @@ class TestRestApi(object):
             "included, or unsupported authentication "
             "method.",
         }
-        mock.post(
+        requests_mock.post(
             "https://www.inaturalist.org/oauth/token",
             json=rejection_json,
             status_code=401,
@@ -246,18 +236,16 @@ class TestRestApi(object):
         with pytest.raises(AuthenticationError):
             get_access_token("username", "password", "app_id", "app_secret")
 
-    @requests_mock.Mocker(kw="mock")
-    def test_get_access_token(self, **kwargs):
+    def test_get_access_token(self, requests_mock):
         """ Test a successful call to get_access_token() """
 
-        mock = kwargs["mock"]
         accepted_json = {
             "access_token": "604e5df329b98eecd22bb0a84f88b68a075a023ac437f2317b02f3a9ba414a08",
             "token_type": "Bearer",
             "scope": "write",
             "created_at": 1539352135,
         }
-        mock.post(
+        requests_mock.post(
             "https://www.inaturalist.org/oauth/token",
             json=accepted_json,
             status_code=200,
@@ -271,10 +259,8 @@ class TestRestApi(object):
             token == "604e5df329b98eecd22bb0a84f88b68a075a023ac437f2317b02f3a9ba414a08"
         )
 
-    @requests_mock.Mocker(kw="mock")
-    def test_update_observation(self, **kwargs):
-        mock = kwargs["mock"]
-        mock.put(
+    def test_update_observation(self, requests_mock):
+        requests_mock.put(
             "https://www.inaturalist.org/observations/17932425.json",
             json=load_sample_json("update_observation_result.json"),
             status_code=200,
@@ -293,11 +279,9 @@ class TestRestApi(object):
         assert r[0]["id"] == 17932425
         assert r[0]["description"] == "updated description v2 !"
 
-    @requests_mock.Mocker(kw="mock")
-    def test_update_nonexistent_observation(self, **kwargs):
+    def test_update_nonexistent_observation(self, requests_mock):
         """When we try to update a non-existent observation, iNat returns an error 410 with "obs does not longer exists". """
-        mock = kwargs["mock"]
-        mock.put(
+        requests_mock.put(
             "https://www.inaturalist.org/observations/999999999.json",
             json={"error": "Cette observation n’existe plus."},
             status_code=410,
@@ -317,11 +301,9 @@ class TestRestApi(object):
             "error": "Cette observation n’existe plus."
         }
 
-    @requests_mock.Mocker(kw="mock")
-    def test_update_observation_not_mine(self, **kwargs):
+    def test_update_observation_not_mine(self, requests_mock):
         """When we try to update the obs of another user, iNat returns an error 410 with "obs does not longer exists"."""
-        mock = kwargs["mock"]
-        mock.put(
+        requests_mock.put(
             "https://www.inaturalist.org/observations/16227955.json",
             json={"error": "Cette observation n’existe plus."},
             status_code=410,
@@ -343,11 +325,8 @@ class TestRestApi(object):
             "error": "Cette observation n’existe plus."
         }
 
-    @requests_mock.Mocker(kw="mock")
-    def test_create_observation(self, **kwargs):
-        mock = kwargs["mock"]
-
-        mock.post(
+    def test_create_observation(self, requests_mock):
+        requests_mock.post(
             "https://www.inaturalist.org/observations.json",
             json=load_sample_json("create_observation_result.json"),
             status_code=200,
@@ -364,9 +343,7 @@ class TestRestApi(object):
         )  # We have the field, but it's none since we didn't submitted anything
         assert r[0]["taxon_id"] == 55626  # Pieris Rapae @ iNaturalist
 
-    @requests_mock.Mocker(kw="mock")
-    def test_create_observation_fail(self, **kwargs):
-        mock = kwargs["mock"]
+    def test_create_observation_fail(self, requests_mock):
         params = {
             "observation": {
                 "species_guess": "Pieris rapae",
@@ -376,7 +353,7 @@ class TestRestApi(object):
             }
         }
 
-        mock.post(
+        requests_mock.post(
             "https://www.inaturalist.org/observations.json",
             json=load_sample_json("create_observation_fail.json"),
             status_code=422,
@@ -389,10 +366,8 @@ class TestRestApi(object):
             "errors" in excinfo.value.response.json()
         )  # iNat also give details about the errors
 
-    @requests_mock.Mocker(kw="mock")
-    def test_put_observation_field_values(self, **kwargs):
-        mock = kwargs["mock"]
-        mock.put(
+    def test_put_observation_field_values(self, requests_mock):
+        requests_mock.put(
             "https://www.inaturalist.org/observation_field_values/31",
             json=load_sample_json("put_observation_field_value_result.json"),
             status_code=200,
@@ -415,22 +390,18 @@ class TestRestApi(object):
         # https://github.com/inaturalist/inaturalist/issues/2252
         pass
 
-    @requests_mock.Mocker(kw="mock")
-    def test_delete_unexisting_observation(self, **kwargs):
+    def test_delete_unexisting_observation(self, requests_mock):
         """ObservationNotFound is raised if the observation doesn't exists"""
-        mock = kwargs["mock"]
-        mock.delete(
+        requests_mock.delete(
             "https://www.inaturalist.org/observations/24774619.json", status_code=404
         )
 
         with pytest.raises(ObservationNotFound):
             delete_observation(observation_id=24774619, access_token="valid token")
 
-    @requests_mock.Mocker(kw="mock")
-    def test_user_agent(self, **kwargs):
+    def test_user_agent(self, requests_mock):
         # TODO: test for all functions that access the inaturalist API?
-        mock = kwargs["mock"]
-        mock.get(
+        requests_mock.get(
             urljoin(INAT_NODE_API_BASE_URL, "observations?id=16227955"),
             json=load_sample_json("get_observation.json"),
             status_code=200,
@@ -441,7 +412,7 @@ class TestRestApi(object):
             "scope": "write",
             "created_at": 1539352135,
         }
-        mock.post(
+        requests_mock.post(
             "https://www.inaturalist.org/oauth/token",
             json=accepted_json,
             status_code=200,
@@ -451,15 +422,15 @@ class TestRestApi(object):
 
         # By default, we have a 'Pyinaturalist' user agent:
         get_observation(observation_id=16227955)
-        assert mock._adapter.last_request._request.headers["User-Agent"] == default_ua
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == default_ua
         get_access_token(
             "valid_username", "valid_password", "valid_app_id", "valid_app_secret"
         )
-        assert mock._adapter.last_request._request.headers["User-Agent"] == default_ua
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == default_ua
 
         # But if the user sets a custom one, it is indeed used:
         get_observation(observation_id=16227955, user_agent="CustomUA")
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA"
         get_access_token(
             "valid_username",
             "valid_password",
@@ -467,28 +438,28 @@ class TestRestApi(object):
             "valid_app_secret",
             user_agent="CustomUA",
         )
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA"
 
         # We can also set it globally:
         pyinaturalist.user_agent = "GlobalUA"
         get_observation(observation_id=16227955)
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
         get_access_token(
             "valid_username", "valid_password", "valid_app_id", "valid_app_secret"
         )
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
 
         # And it persists across requests:
         get_observation(observation_id=16227955)
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
         get_access_token(
             "valid_username", "valid_password", "valid_app_id", "valid_app_secret"
         )
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "GlobalUA"
 
         # But if we have a global and local one, the local has priority
         get_observation(observation_id=16227955, user_agent="CustomUA 2")
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA 2"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA 2"
         get_access_token(
             "valid_username",
             "valid_password",
@@ -496,13 +467,13 @@ class TestRestApi(object):
             "valid_app_secret",
             user_agent="CustomUA 2",
         )
-        assert mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA 2"
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == "CustomUA 2"
 
         # We can reset the global settings to the default:
         pyinaturalist.user_agent = pyinaturalist.DEFAULT_USER_AGENT
         get_observation(observation_id=16227955)
-        assert mock._adapter.last_request._request.headers["User-Agent"] == default_ua
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == default_ua
         get_access_token(
             "valid_username", "valid_password", "valid_app_id", "valid_app_secret"
         )
-        assert mock._adapter.last_request._request.headers["User-Agent"] == default_ua
+        assert requests_mock._adapter.last_request._request.headers["User-Agent"] == default_ua


### PR DESCRIPTION
This PR takes the `node_api` parameter conversion/validation changes for issues #17 and #19 and applies them to all the endpoints in the `rest_api` module. To do this with minimal code duplication, this also adds an `api_requests` module for request-related functions shared by both API modules. Closes #17 .

To ensure uniform coverage, there are unit tests to dynamically find all HTTP request functions, and make sure that each one calls `preprocess_request_params()` at some point (either individually or via one of the wrapper functions in `api_requests`). Theoretically that will also check any future endpoints that are added.