### PR TITLE
Add a dry-run option for testing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ History
 * Added more info & examples to README for taxa endpoints
 * Added `minify` option to `node_api.get_taxa_autocomplete()`
 * Convert all date and datetime parameters to timezone-aware ISO 8601 timestamps
+* Added a dry-run mode to mock out API requests for testing
 
 0.9.1 (2020-05-26)
 ++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -236,3 +236,46 @@ info. For example:
     "Schlumbergera truncata"
     >>> first_result["matched_term"]
     "Zygocactus truncatus"  # An older synonym for Schlumbergera
+
+
+Dry-run mode
+------------
+While developing & testing an application that uses an API client like pyinaturalist, it can be
+useful to temporarily mock out HTTP requests, especially requests that add, modify, or delete
+real data. Pyinaturalist has some settings to make this easier.
+
+Dry-run all requests
+^^^^^^^^^^^^^^^^^^^^
+To enable dry-run mode, set the ``DRY_RUN_ENABLED`` variable. When set, requests will not be sent
+but will be logged instead:
+
+.. code-block:: python
+
+    >>> import pyinaturalist
+    >>> pyinaturalist.DRY_RUN_ENABLED = True
+    >>> get_taxa(q='warbler', locale=1)
+    {'results': ['nodata']}
+    INFO:pyinaturalist.api_requests:Request: GET, https://api.inaturalist.org/v1/taxa,
+        params={'q': 'warbler', 'locale': 1},
+        headers={'Accept': 'application/json', 'User-Agent': 'Pyinaturalist/0.9.1'}
+
+Or, if you are running your application in a command-line environment, you can set this as an
+environment variable instead (case-insensitive):
+
+.. code-block:: bash
+
+    $ export DRY_RUN_ENABLED=true
+    $ python my_script.py
+
+Dry-run only write requests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you would like to run ``GET`` requests but mock out any requests that modify data
+(``POST``, ``PUT``, ``DELETE``, etc.), you can use the ``DRY_RUN_WRITE_ONLY`` variable
+instead:
+
+.. code-block:: python
+
+    >>> pyinaturalist.DRY_RUN_WRITE_ONLY = True
+    # Also works as an environment variable
+    >>> import os
+    >>> os.environ["DRY_RUN_WRITE_ONLY"] = 'True'

--- a/pyinaturalist/__init__.py
+++ b/pyinaturalist/__init__.py
@@ -5,8 +5,10 @@ __email__ = "nicolas@niconoe.eu"
 __version__ = "0.9.1"
 
 DEFAULT_USER_AGENT = "Pyinaturalist/{version}".format(version=__version__)
-
 user_agent = DEFAULT_USER_AGENT
+
+# These are imported here so they can be set with pyinaturalist.<variable>
+from pyinaturalist.constants import DRY_RUN_ENABLED, DRY_RUN_WRITE_ONLY
 
 # Enable logging for urllib and other external loggers
 logging.basicConfig(level="DEBUG")

--- a/pyinaturalist/api_requests.py
+++ b/pyinaturalist/api_requests.py
@@ -3,6 +3,7 @@ import requests
 from typing import Dict
 
 import pyinaturalist
+from pyinaturalist.constants import DRY_RUN_ENABLED, MOCK_RESPONSE
 from pyinaturalist.helpers import preprocess_request_params
 
 
@@ -53,3 +54,14 @@ def request(
     params = preprocess_request_params(params)
 
     return requests.request(method, url, params=params, headers=headers, **kwargs)
+
+
+# Make dryable an optional dependency; if it is not installed, its decorator will not be applied.
+# Dryable must be both installed and enabled before requests are mocked.
+try:
+    import dryable
+
+    dryable.set(DRY_RUN_ENABLED)
+    request = dryable.Dryable(value=MOCK_RESPONSE)(request)
+except ImportError:
+    pass

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -1,7 +1,17 @@
+import os
+import requests
+from unittest.mock import Mock
+
 INAT_NODE_API_BASE_URL = "https://api.inaturalist.org/v1/"
 INAT_BASE_URL = "https://www.inaturalist.org"
 
-THROTTLING_DELAY = 1  # In seconds, support <0 floats such as 0.1
+THROTTLING_DELAY = 1  # In seconds, support <1 floats such as 0.1
+
+# Toggle dry-run mode: this will run and log mock HTTP requests instead of real ones
+DRY_RUN_ENABLED = bool(os.getenv("DRY_RUN_ENABLED"))
+# Mock response content to return in dry-run mode
+MOCK_RESPONSE = Mock(spec=requests.Response)
+MOCK_RESPONSE.json.return_value = {"results": ["nodata"]}
 
 # All request parameters from both Node API and REST (Rails) API that accept date or datetime strings
 DATETIME_PARAMS = [

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -1,4 +1,3 @@
-import os
 import requests
 from unittest.mock import Mock
 
@@ -8,7 +7,7 @@ INAT_BASE_URL = "https://www.inaturalist.org"
 THROTTLING_DELAY = 1  # In seconds, support <1 floats such as 0.1
 
 # Toggle dry-run mode: this will run and log mock HTTP requests instead of real ones
-DRY_RUN_ENABLED = bool(os.getenv("DRY_RUN_ENABLED"))
+DRY_RUN_ENABLED = False
 # Mock response content to return in dry-run mode
 MOCK_RESPONSE = Mock(spec=requests.Response)
 MOCK_RESPONSE.json.return_value = {"results": ["nodata"]}

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -7,7 +7,9 @@ INAT_BASE_URL = "https://www.inaturalist.org"
 THROTTLING_DELAY = 1  # In seconds, support <1 floats such as 0.1
 
 # Toggle dry-run mode: this will run and log mock HTTP requests instead of real ones
-DRY_RUN_ENABLED = False
+DRY_RUN_ENABLED = False  # Mock all requests, including GET
+DRY_RUN_WRITE_ONLY = False  # Only mock 'write' requests
+WRITE_HTTP_METHODS = ["PATCH", "POST", "PUT", "DELETE"]
 # Mock response content to return in dry-run mode
 MOCK_RESPONSE = Mock(spec=requests.Response)
 MOCK_RESPONSE.json.return_value = {"results": ["nodata"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ cffi==1.11.5
 chardet==3.0.4
 cmarkgfm==0.4.2
 docutils==0.14
-dryable==1.0.5
 filelock==3.0.9
 future==0.16.0
 idna==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ cffi==1.11.5
 chardet==3.0.4
 cmarkgfm==0.4.2
 docutils==0.14
+dryable==1.0.5
 filelock==3.0.9
 future==0.16.0
 idna==2.7

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     extras_require={
         "dev": [
             "black",
+            "dryable",
             "flake8",
             "mypy",
             "pytest",

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,10 @@ setup(
     packages=["pyinaturalist"],
     package_dir={"pyinaturalist": "pyinaturalist"},
     include_package_data=True,
-    install_requires=["python-dateutil>=2.0", "requests>=2.21.0", "typing>=3.7.4"],
+    install_requires=["python-dateutil>=2.0", "requests>=2.21.0", "typing>=3.7.4",],
     extras_require={
         "dev": [
             "black",
-            "dryable",
             "flake8",
             "mypy",
             "pytest",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=["pyinaturalist"],
     package_dir={"pyinaturalist": "pyinaturalist"},
     include_package_data=True,
-    install_requires=["python-dateutil>=2.0", "requests>=2.21.0", "typing>=3.7.4",],
+    install_requires=["python-dateutil>=2.0", "requests>=2.21.0", "typing>=3.7.4"],
     extras_require={
         "dev": [
             "black",
@@ -40,7 +40,7 @@ setup(
             "sphinx-autodoc-typehints",
             "sphinx-rtd-theme",
             "tox",
-            "twine"
+            "twine",
         ]
     },
     license="MIT",

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -53,16 +53,16 @@ def test_request_dry_run_disabled(requests_mock):
     assert request("GET", "http://url",).json() == real_response
 
 
-# TODO: Figure out the least ugly method of mocking this
-# @patch("pyinaturalist.api_requests.DRY_RUN_ENABLED")
-def test_request_dry_run_enabled():
-    real_response = {"results": ["I'm a real response object!"]}
-    # requests_mock.get("http://url", json=real_response, status_code=200)
-    # with patch.dict(os.environ, {"DRY_RUN_ENABLED": "True"}):
-    # with patch("pyinaturalist.api_requests.DRY_RUN_ENABLED", True):
-
-    import dryable
-
-    dryable.set(True)
+@patch("pyinaturalist.api_requests.DRY_RUN_ENABLED")
+@patch("pyinaturalist.api_requests.requests")
+def test_request_dry_run_enabled__by_constant(mock_requests, mock_dry_run_enabled):
     assert request("GET", "http://url") == MOCK_RESPONSE
-    dryable.set(False)
+    assert mock_requests.call_count == 0
+
+
+@patch("pyinaturalist.api_requests.getenv", return_value = 'True')
+@patch("pyinaturalist.api_requests.requests")
+def test_request_dry_run_enabled__by_envar(mock_requests, mock_os):
+    # mock_os.getenv.return_value = 'True'
+    assert request("GET", "http://url") == MOCK_RESPONSE
+    assert mock_requests.call_count == 0

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -1,8 +1,10 @@
+import os
 import pytest
 from unittest.mock import patch
 
 import pyinaturalist
 from pyinaturalist.api_requests import delete, get, post, put, request
+from pyinaturalist.constants import MOCK_RESPONSE
 
 
 # Just test that the wrapper methods call requests.request with the appropriate HTTP method
@@ -27,7 +29,11 @@ def test_http_methods(mock_request, function, http_method):
         ),
         (
             {"access_token": "token"},
-            {"Accept": "application/json", "User-Agent": pyinaturalist.user_agent, "Authorization": "Bearer token"},
+            {
+                "Accept": "application/json",
+                "User-Agent": pyinaturalist.user_agent,
+                "Authorization": "Bearer token",
+            },
         ),
     ],
 )
@@ -36,3 +42,27 @@ def test_request_headers(mock_request, input_kwargs, expected_headers):
     request("GET", "https://url", **input_kwargs)
     request_kwargs = mock_request.call_args[1]
     assert request_kwargs["headers"] == expected_headers
+
+
+def test_request_dry_run_disabled(requests_mock):
+    real_response = {"results": ["I'm a real response object!"]}
+    requests_mock.get(
+        "http://url", json={"results": ["I'm a real response object!"]}, status_code=200
+    )
+
+    assert request("GET", "http://url",).json() == real_response
+
+
+# TODO: Figure out the least ugly method of mocking this
+# @patch("pyinaturalist.api_requests.DRY_RUN_ENABLED")
+def test_request_dry_run_enabled():
+    real_response = {"results": ["I'm a real response object!"]}
+    # requests_mock.get("http://url", json=real_response, status_code=200)
+    # with patch.dict(os.environ, {"DRY_RUN_ENABLED": "True"}):
+    # with patch("pyinaturalist.api_requests.DRY_RUN_ENABLED", True):
+
+    import dryable
+
+    dryable.set(True)
+    assert request("GET", "http://url") == MOCK_RESPONSE
+    dryable.set(False)

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -44,6 +44,74 @@ def test_request_headers(mock_request, input_kwargs, expected_headers):
     assert request_kwargs["headers"] == expected_headers
 
 
+# Test relevant combinations of dry-run settings and HTTP methods
+@pytest.mark.parametrize(
+    "enabled_const, enabled_env, write_only_const, write_only_env, method, expected_real_request",
+    [
+        # DRY_RUN_ENABLED constant or envar should mock GETs, but not DRY_RUN_WRITE_ONLY
+        (False, False, False, False, "GET", True),
+        (False, False, True, True, "GET", True),
+        (False, False, False, False, "HEAD", True),
+        (True, False, False, False, "GET", False),
+        (False, True, False, False, "GET", False),
+        # Either DRY_RUN_ENABLED or DRY_RUN_WRITE_ONLY should mock POST requests
+        (False, False, False, False, "POST", True),
+        (True, False, False, False, "POST", False),
+        (False, True, False, False, "POST", False),
+        (False, False, True, False, "POST", False),
+        (False, False, False, True, "POST", False),
+        (False, False, True, False, "POST", False),
+        # Same for the other write methods
+        (False, False, False, False, "PUT", True),
+        (False, False, False, False, "DELETE", True),
+        (False, False, False, True, "PUT", False),
+        (False, False, False, True, "DELETE", False),
+        # Truthy environment variable strings should be respected
+        (False, "true", False, False, "GET", False),
+        (False, "True", False, "False", "PUT", False),
+        (False, False, False, "True", "DELETE", False),
+        # As well as "falsy" environment variable strings
+        (False, "false", False, False, "GET", True),
+        (False, "none", False, "False", "POST", True),
+        (False, False, False, "None", "DELETE", True),
+    ],
+)
+@patch("pyinaturalist.api_requests.getenv")
+@patch("pyinaturalist.api_requests.requests")
+def test_request_dry_run(
+    mock_requests,
+    mock_getenv,
+    enabled_const,
+    enabled_env,
+    write_only_const,
+    write_only_env,
+    method,
+    expected_real_request,
+):
+    # Mock any environment variables specified
+    env_vars = {}
+    if enabled_env is not None:
+        env_vars["DRY_RUN_ENABLED"] = enabled_env
+    if write_only_env is not None:
+        env_vars["DRY_RUN_WRITE_ONLY"] = write_only_env
+    mock_getenv.side_effect = env_vars.__getitem__
+
+    # Mock constants and run request
+    with patch("pyinaturalist.api_requests.pyinaturalist") as settings:
+        settings.DRY_RUN_ENABLED = enabled_const
+        settings.DRY_RUN_WRITE_ONLY = write_only_const
+        response = request(method, "http://url")
+
+    # Verify that the request was or wasn""t mocked based on settings
+    if expected_real_request:
+        assert mock_requests.request.call_count == 1
+        assert response == mock_requests.request()
+    else:
+        assert response == MOCK_RESPONSE
+        assert mock_requests.request.call_count == 0
+
+
+# In addition to the test cases above, ensure that the request/response isn't altered with dry-run disabled
 def test_request_dry_run_disabled(requests_mock):
     real_response = {"results": ["I'm a real response object!"]}
     requests_mock.get(
@@ -51,18 +119,3 @@ def test_request_dry_run_disabled(requests_mock):
     )
 
     assert request("GET", "http://url",).json() == real_response
-
-
-@patch("pyinaturalist.api_requests.DRY_RUN_ENABLED")
-@patch("pyinaturalist.api_requests.requests")
-def test_request_dry_run_enabled__by_constant(mock_requests, mock_dry_run_enabled):
-    assert request("GET", "http://url") == MOCK_RESPONSE
-    assert mock_requests.call_count == 0
-
-
-@patch("pyinaturalist.api_requests.getenv", return_value = 'True')
-@patch("pyinaturalist.api_requests.requests")
-def test_request_dry_run_enabled__by_envar(mock_requests, mock_os):
-    # mock_os.getenv.return_value = 'True'
-    assert request("GET", "http://url") == MOCK_RESPONSE
-    assert mock_requests.call_count == 0

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -89,11 +89,7 @@ def test_preprocess_request_params(mock_bool, mock_datetime, mock_list, mock_str
 @patch("pyinaturalist.api_requests.preprocess_request_params")
 @patch("pyinaturalist.api_requests.requests.request")
 def test_all_node_requests_use_param_conversion(
-    request,
-    preprocess_request_params,
-    merge_two_dicts,
-    get_rank_range,
-    http_function,
+    request, preprocess_request_params, merge_two_dicts, get_rank_range, http_function,
 ):
     request().json.return_value = {"total_results": 1, "results": [{}]}
     mock_args = get_mock_args_for_signature(http_function)


### PR DESCRIPTION
This PR adds a `DRY_RUN_ENABLED` constant and environment variable. When set, API requests will just be logged and not run. Closes #9 .

PR #22 does most of the prep work for this, so the changes needed are pretty trivial at this point, and don't require adding any dependencies.

- [x] Add a `DRY_RUN_ENABLED` constant and environment variable
- [x] Implement dry-run mode
- [x] Make separate settings for read-only (`GET`) methods and write (`POST`, `PUT`, `DELETE`) methods
- [x] Add unit tests
- [x] Update docs