### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+
+python:
+  version: 3.7
+  system_packages: True
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python
+from itertools import chain
 from sys import version_info
 from setuptools import setup, find_packages
 from pyinaturalist import __version__
 
 # Only install the typing backport if we're on python < 3.5
 backports = ["typing>=3.7.4"] if version_info < (3, 5) else []
+
+# These package categories allow tox and build environments to install only what they need
+extras_require = {
+    # Packages used for CI jobs
+    "build": ["coveralls", "tox-travis"],
+    # Packages used for documentation builds
+    "docs": ["Sphinx>=3.0", "sphinx-rtd-theme", "sphinxcontrib-apidoc"],
+    # Packages used for testing both locally and in CI jobs
+    "test": ["black", "flake8", "mypy", "pytest", "pytest-cov", "requests-mock>=1.7", "tox"],
+}
+# All development/testing packages combined
+extras_require["dev"] = list(chain.from_iterable(extras_require.values()))
 
 
 setup(
@@ -16,21 +29,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=["python-dateutil>=2.0", "requests>=2.21.0"] + backports,
-    extras_require={
-        "dev": [
-            "black",
-            "flake8",
-            "mypy",
-            "pytest",
-            "pytest-cov",
-            "requests-mock>=1.7",
-            "Sphinx>=3.0",
-            "sphinx-rtd-theme",
-            "sphinxcontrib-apidoc",
-            "tox",
-        ],
-        # Additional packages used only within CI jobs
-        "build": ["coveralls", "tox-travis"],
-    },
+    extras_require=extras_require,
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,8 @@ envlist =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}/pyinaturalist
-extras = dev
-commands =
-    pytest --basetemp={envtmpdir}
+extras = test
+commands = pytest --basetemp={envtmpdir}
 whitelist_externals =
     printf
     make
@@ -46,17 +45,17 @@ deps =
 extras =
 
 [testenv:docs]
-commands =
-    make -C docs all
+extras =
+    test
+    docs
+commands = make -C docs all
 
 [testenv:lint]
-commands =
-    python setup.py flake8
+commands = python setup.py flake8
 
 # Build and check distributions without deploying, just to make sure they can build correctly
 [testenv:dist-test]
-deps =
-    twine
+deps = twine
 commands =
     python setup.py sdist bdist_wheel
     twine check dist/*


### PR DESCRIPTION
This fixes a failing readthedocs build due to its builder using an outdated Sphinx version.

* Make optional dependencies more granular for tests/docs/builds
* Add readthedocs config file to ensure correct Sphinx version

Otherwise there are no functional changes to the code, so there's no need to tag and rebuild the package.