### PR TITLE
Added observations/species_counts endpoint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,7 @@ New Endpoints
 * Added new function for an additional Node API **Observation** endpoint:
 
     * ``get_observation_species_counts()``
+    * ``get_all_observation_species_counts()``
 
 Modified Endpoints
 ~~~~~~~~~~~~~~~~~~~~

--- a/pyinaturalist/api_docs.py
+++ b/pyinaturalist/api_docs.py
@@ -491,6 +491,7 @@ _get_observations = [
 get_observations_params = _get_observations + [_pagination, _only_id]
 get_all_observations_params = _get_observations + [_only_id]
 get_observation_species_counts_params = _get_observations
+get_all_observation_species_counts_params = _get_observations
 get_geojson_observations_params = _get_observations + [_geojson_properties]
 get_places_nearby_params = [_bounding_box, _name]
 get_projects_params = [_projects_params, _pagination]

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -154,7 +154,7 @@ def get_all_observations(
         id_above = results[-1]["id"]
 
 
-@document_request_params(get_observation_species_counts_params)
+# @document_request_params(get_observation_species_counts_params)
 def get_observation_species_counts(user_agent: str = None, **kwargs) -> JsonResponse:
     """Get all species (or other "leaf taxa") associated with observations matching the search
     criteria, and the count of observations they are associated with.
@@ -183,14 +183,28 @@ def get_observation_species_counts(user_agent: str = None, **kwargs) -> JsonResp
     return r.json()
 
 
-@document_request_params(get_all_observation_species_counts_params)
+# @document_request_params(get_all_observation_species_counts_params)
 def get_all_observation_species_counts(user_agent: str = None, **kwargs) -> List[JsonResponse]:
     """Like :py:func:`get_observation_species_counts()`, but handles pagination and returns all
     results in one call. Explicit pagination parameters will be ignored.
 
     Notes:
-    While the `page` parameter is undocumented for observations/species_counts, it appears to be supported.
-    `id_above` and `id_below` are not helpful in the context.
+    While the ``page`` parameter is undocumented for observations/species_counts, it appears to be supported.
+    ``id_above`` and ``id_below`` are not helpful in the context.
+
+    Example:
+        >>> get_all_observation_species_counts(
+        ...     user_agent=None,
+        ...     quality_grade='research',
+        ...     place_id=154695,
+        ...     iconic_taxa='Reptilia',
+        ... )
+
+        .. admonition:: Example Response
+            :class: toggle
+
+            .. literalinclude:: ../sample_data/get_all_observation_species_counts_ex_results.json
+                :language: JSON
 
     Returns:
         Combined list of taxon records with counts
@@ -203,7 +217,7 @@ def get_all_observation_species_counts(user_agent: str = None, **kwargs) -> List
         **kwargs,
         **{
             "per_page": PER_PAGE_RESULTS,
-            # "user_agent": user_agent,
+            "user_agent": user_agent,
         },
     }
 

--- a/test/sample_data/get_all_observation_species_counts_ex_results.json
+++ b/test/sample_data/get_all_observation_species_counts_ex_results.json
@@ -1,0 +1,432 @@
+[
+  {
+    "count": 15,
+    "taxon": {
+      "observations_count": 19592,
+      "taxon_schemes_count": 5,
+      "ancestry": "48460/1/2/355675/26036/26172/85553/26504/532896/29299",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 1
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Northern_water_snake",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 0,
+      "atlas_id": 214,
+      "complete_species_count": null,
+      "parent_id": 29299,
+      "complete_rank": "subspecies",
+      "name": "Nerodia sipedon",
+      "rank": "species",
+      "extinct": false,
+      "id": 29305,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/71155458/square.jpg?1588607979",
+        "attribution": "(c) rosalie-rick, all rights reserved",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/71155458/medium.jpg?1588607979",
+        "id": 71155458,
+        "license_code": null,
+        "original_dimensions": {
+          "width": 2048,
+          "height": 1365
+        },
+        "url": "https://static.inaturalist.org/photos/71155458/square.jpg?1588607979"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        26172,
+        85553,
+        26504,
+        532896,
+        29299,
+        29305
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Common Watersnake"
+    }
+  },
+  {
+    "count": 6,
+    "taxon": {
+      "observations_count": 26586,
+      "taxon_schemes_count": 7,
+      "ancestry": "48460/1/2/355675/26036/39532/39680/39681",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 6
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Common_snapping_turtle",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 1,
+      "atlas_id": 638,
+      "complete_species_count": null,
+      "parent_id": 39681,
+      "complete_rank": "subspecies",
+      "name": "Chelydra serpentina",
+      "rank": "species",
+      "extinct": false,
+      "id": 39682,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/493231/square.jpg?1378868682",
+        "attribution": "(c) Keegan Smith, all rights reserved",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/493231/medium.jpg?1378868682",
+        "id": 493231,
+        "license_code": null,
+        "original_dimensions": {
+          "width": 720,
+          "height": 481
+        },
+        "url": "https://static.inaturalist.org/photos/493231/square.jpg?1378868682"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        39532,
+        39680,
+        39681,
+        39682
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Snapping Turtle"
+    }
+  },
+  {
+    "count": 4,
+    "taxon": {
+      "observations_count": 2353,
+      "taxon_schemes_count": 5,
+      "ancestry": "48460/1/2/355675/26036/26172/85553/26504/797518/27383",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 0
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Carphophis_amoenus",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 0,
+      "atlas_id": 177,
+      "complete_species_count": null,
+      "parent_id": 27383,
+      "complete_rank": "subspecies",
+      "name": "Carphophis amoenus",
+      "rank": "species",
+      "extinct": false,
+      "id": 27388,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/13472008/square.jpg?1518459786",
+        "attribution": "(c) Zach Lim, some rights reserved (CC BY-NC)",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/13472008/medium.jpg?1518459786",
+        "id": 13472008,
+        "license_code": "cc-by-nc",
+        "original_dimensions": {
+          "width": 2048,
+          "height": 1366
+        },
+        "url": "https://static.inaturalist.org/photos/13472008/square.jpg?1518459786"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        26172,
+        85553,
+        26504,
+        797518,
+        27383,
+        27388
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Eastern Worm Snake"
+    }
+  },
+  {
+    "count": 4,
+    "taxon": {
+      "observations_count": 789,
+      "taxon_schemes_count": 2,
+      "ancestry": "48460/1/2/355675/26036/26172/85553/26504/797520/29768",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 0
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Lampropeltis_nigra",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 2,
+      "atlas_id": 701,
+      "complete_species_count": null,
+      "parent_id": 29768,
+      "complete_rank": "subspecies",
+      "name": "Lampropeltis nigra",
+      "rank": "species",
+      "extinct": false,
+      "id": 60348,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/12050719/square.jpeg?1511726087",
+        "attribution": "(c) Tristan Clark, some rights reserved (CC BY-NC)",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/12050719/medium.jpeg?1511726087",
+        "id": 12050719,
+        "license_code": "cc-by-nc",
+        "original_dimensions": {
+          "width": 2048,
+          "height": 1282
+        },
+        "url": "https://static.inaturalist.org/photos/12050719/square.jpeg?1511726087"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        26172,
+        85553,
+        26504,
+        797520,
+        29768,
+        60348
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Black Kingsnake"
+    }
+  },
+  {
+    "count": 2,
+    "taxon": {
+      "observations_count": 5053,
+      "taxon_schemes_count": 3,
+      "ancestry": "48460/1/2/355675/26036/26172/85553/26504/797520/59649/857190",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 2
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Gray_ratsnake",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 2,
+      "atlas_id": 695,
+      "complete_species_count": null,
+      "parent_id": 857190,
+      "complete_rank": "subspecies",
+      "name": "Pantherophis spiloides",
+      "rank": "species",
+      "extinct": false,
+      "id": 67642,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/3067893/square.jpg?1456535053",
+        "attribution": "(c) Diana-Terry Hibbitts, some rights reserved (CC BY-NC)",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/3067893/medium.jpg?1456535053",
+        "id": 3067893,
+        "license_code": "cc-by-nc",
+        "original_dimensions": {
+          "width": 800,
+          "height": 533
+        },
+        "url": "https://static.inaturalist.org/photos/3067893/square.jpg?1456535053"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        26172,
+        85553,
+        26504,
+        797520,
+        59649,
+        857190,
+        67642
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Gray Ratsnake"
+    }
+  },
+  {
+    "count": 1,
+    "taxon": {
+      "observations_count": 6479,
+      "taxon_schemes_count": 3,
+      "ancestry": "48460/1/2/355675/26036/26172/85552/36074/797562/36141",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 1
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Eastern_fence_lizard",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 1,
+      "atlas_id": 694,
+      "complete_species_count": null,
+      "parent_id": 36141,
+      "complete_rank": "subspecies",
+      "name": "Sceloporus undulatus",
+      "rank": "species",
+      "extinct": false,
+      "id": 36142,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/4753638/square.jpeg?1472877457",
+        "attribution": "(c) Matt Muir, some rights reserved (CC BY-SA)",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/4753638/medium.jpeg?1472877457",
+        "id": 4753638,
+        "license_code": "cc-by-sa",
+        "original_dimensions": {
+          "width": 2048,
+          "height": 1538
+        },
+        "url": "https://static.inaturalist.org/photos/4753638/square.jpeg?1472877457"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        26172,
+        85552,
+        36074,
+        797562,
+        36141,
+        36142
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Eastern Fence Lizard"
+    }
+  },
+  {
+    "count": 1,
+    "taxon": {
+      "observations_count": 46630,
+      "taxon_schemes_count": 8,
+      "ancestry": "48460/1/2/355675/26036/39532/39760/797544/39776",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 0
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Pond_slider",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 0,
+      "atlas_id": 829,
+      "complete_species_count": null,
+      "parent_id": 39776,
+      "complete_rank": "subspecies",
+      "name": "Trachemys scripta",
+      "rank": "species",
+      "extinct": false,
+      "id": 39782,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/27092877/square.jpg?1545342047",
+        "attribution": "(c) Linda De Volder, some rights reserved (CC BY-NC-ND)",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/27092877/medium.jpg?1545342047",
+        "id": 27092877,
+        "license_code": "cc-by-nc-nd",
+        "original_dimensions": {
+          "width": 2048,
+          "height": 1354
+        },
+        "url": "https://static.inaturalist.org/photos/27092877/square.jpg?1545342047"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        39532,
+        39760,
+        797544,
+        39776,
+        39782
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Common Slider"
+    }
+  },
+  {
+    "count": 1,
+    "taxon": {
+      "observations_count": 11525,
+      "taxon_schemes_count": 5,
+      "ancestry": "48460/1/2/355675/26036/26172/85552/36982/787700/37763",
+      "is_active": true,
+      "flag_counts": {
+        "unresolved": 0,
+        "resolved": 0
+      },
+      "wikipedia_url": "http://en.wikipedia.org/wiki/Plestiodon_fasciatus",
+      "current_synonymous_taxon_ids": null,
+      "iconic_taxon_id": 26036,
+      "rank_level": 10,
+      "taxon_changes_count": 0,
+      "atlas_id": 223,
+      "complete_species_count": null,
+      "parent_id": 37763,
+      "complete_rank": "subspecies",
+      "name": "Plestiodon fasciatus",
+      "rank": "species",
+      "extinct": false,
+      "id": 73788,
+      "default_photo": {
+        "square_url": "https://static.inaturalist.org/photos/6973322/square.jpg?1491829047",
+        "attribution": "(c) Tracey Fandre, some rights reserved (CC BY-NC-ND)",
+        "flags": [],
+        "medium_url": "https://static.inaturalist.org/photos/6973322/medium.jpg?1491829047",
+        "id": 6973322,
+        "license_code": "cc-by-nc-nd",
+        "original_dimensions": {
+          "width": 1638,
+          "height": 2048
+        },
+        "url": "https://static.inaturalist.org/photos/6973322/square.jpg?1491829047"
+      },
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        26036,
+        26172,
+        85552,
+        36982,
+        787700,
+        37763,
+        73788
+      ],
+      "iconic_taxon_name": "Reptilia",
+      "preferred_common_name": "Common Five-lined Skink"
+    }
+  }
+]

--- a/test/sample_data/get_all_observation_species_counts_page1.json
+++ b/test/sample_data/get_all_observation_species_counts_page1.json
@@ -1,0 +1,686 @@
+{
+  "total_results": 22,
+  "page": 1,
+  "per_page": 30,
+  "results": [
+    {
+      "count": 19,
+      "taxon": {
+        "observations_count": 17261,
+        "taxon_schemes_count": 8,
+        "ancestry": "48460/1/2/355675/20978/26718/27701/787591/27800",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Eastern_newt",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 229,
+        "complete_species_count": null,
+        "parent_id": 27800,
+        "name": "Notophthalmus viridescens",
+        "rank": "species",
+        "extinct": false,
+        "id": 27805,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/48283767/square.jpg?1565893595",
+          "attribution": "(c) mattbuckingham, alle Rechte vorbehalten",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/48283767/medium.jpg?1565893595",
+          "id": 48283767,
+          "license_code": null,
+          "original_dimensions": {
+            "width": 1024,
+            "height": 732
+          },
+          "url": "https://static.inaturalist.org/photos/48283767/square.jpg?1565893595"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          26718,
+          27701,
+          787591,
+          27800,
+          27805
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Eastern Newt"
+      }
+    },
+    {
+      "count": 17,
+      "taxon": {
+        "observations_count": 19543,
+        "taxon_schemes_count": 5,
+        "ancestry": "48460/1/2/355675/26036/26172/85553/26504/532896/29299",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Northern_water_snake",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 214,
+        "complete_species_count": null,
+        "parent_id": 29299,
+        "complete_rank": "subspecies",
+        "name": "Nerodia sipedon",
+        "rank": "species",
+        "extinct": false,
+        "id": 29305,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/71155458/square.jpg?1588607979",
+          "attribution": "(c) rosalie-rick, all rights reserved",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/71155458/medium.jpg?1588607979",
+          "id": 71155458,
+          "license_code": null,
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1365
+          },
+          "url": "https://static.inaturalist.org/photos/71155458/square.jpg?1588607979"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          26172,
+          85553,
+          26504,
+          532896,
+          29299,
+          29305
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Common Watersnake"
+      }
+    },
+    {
+      "count": 16,
+      "taxon": {
+        "observations_count": 32582,
+        "taxon_schemes_count": 7,
+        "ancestry": "48460/1/2/355675/20978/20979/25473/60340",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 2
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Lithobates_clamitans",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 2,
+        "atlas_id": 477,
+        "complete_species_count": null,
+        "parent_id": 60340,
+        "name": "Lithobates clamitans",
+        "rank": "species",
+        "extinct": false,
+        "id": 65982,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/7660373/square.jpg?1494121256",
+          "attribution": "(c) Buddy, all rights reserved",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/7660373/medium.jpg?1494121256",
+          "id": 7660373,
+          "license_code": null,
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1607
+          },
+          "url": "https://static.inaturalist.org/photos/7660373/square.jpg?1494121256"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          20979,
+          25473,
+          60340,
+          65982
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Green Frog"
+      }
+    },
+    {
+      "count": 13,
+      "taxon": {
+        "observations_count": 3323,
+        "taxon_schemes_count": 7,
+        "ancestry": "48460/1/2/355675/20978/26718/26909/787551/27135",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Northern_slimy_salamander",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 2,
+        "atlas_id": 469,
+        "complete_species_count": null,
+        "parent_id": 27135,
+        "name": "Plethodon glutinosus",
+        "rank": "species",
+        "extinct": false,
+        "id": 27184,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/19621331/square.jpg?1528850343",
+          "attribution": "(c) bugman83, algunos derechos reservados (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/19621331/medium.jpg?1528850343",
+          "id": 19621331,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 960,
+            "height": 689
+          },
+          "url": "https://static.inaturalist.org/photos/19621331/square.jpg?1528850343"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          26718,
+          26909,
+          787551,
+          27135,
+          27184
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Northern Slimy Salamander"
+      }
+    },
+    {
+      "count": 10,
+      "taxon": {
+        "observations_count": 30979,
+        "taxon_schemes_count": 9,
+        "ancestry": "48460/1/2/355675/20978/20979/25473/60340",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/American_bullfrog",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 1,
+        "atlas_id": 510,
+        "complete_species_count": null,
+        "parent_id": 60340,
+        "name": "Lithobates catesbeianus",
+        "rank": "species",
+        "extinct": false,
+        "id": 65979,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/4654051/square.jpg?1471994899",
+          "attribution": "(c) bubbacho, some rights reserved (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/4654051/medium.jpg?1471994899",
+          "id": 4654051,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1414
+          },
+          "url": "https://static.inaturalist.org/photos/4654051/square.jpg?1471994899"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          20979,
+          25473,
+          60340,
+          65979
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "American Bullfrog"
+      }
+    },
+    {
+      "count": 9,
+      "taxon": {
+        "observations_count": 644,
+        "taxon_schemes_count": 7,
+        "ancestry": "48460/1/2/355675/20978/26718/26909/787551/27380",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": null,
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 1,
+        "atlas_id": 435,
+        "complete_species_count": null,
+        "parent_id": 27380,
+        "name": "Desmognathus conanti",
+        "rank": "species",
+        "extinct": false,
+        "id": 27392,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/1980265/square.JPG?1433863926",
+          "attribution": "(c) johnwilliams, some rights reserved (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/1980265/medium.JPG?1433863926",
+          "id": 1980265,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 1024,
+            "height": 680
+          },
+          "url": "https://static.inaturalist.org/photos/1980265/square.JPG?1433863926"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          26718,
+          26909,
+          787551,
+          27380,
+          27392
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Spotted Dusky Salamander"
+      }
+    },
+    {
+      "count": 7,
+      "taxon": {
+        "observations_count": 11508,
+        "taxon_schemes_count": 5,
+        "ancestry": "48460/1/2/355675/26036/26172/85552/36982/787700/37763",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Plestiodon_fasciatus",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 223,
+        "complete_species_count": null,
+        "parent_id": 37763,
+        "complete_rank": "subspecies",
+        "name": "Plestiodon fasciatus",
+        "rank": "species",
+        "extinct": false,
+        "id": 73788,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/6973322/square.jpg?1491829047",
+          "attribution": "(c) Tracey Fandre, some rights reserved (CC BY-NC-ND)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/6973322/medium.jpg?1491829047",
+          "id": 6973322,
+          "license_code": "cc-by-nc-nd",
+          "original_dimensions": {
+            "width": 1638,
+            "height": 2048
+          },
+          "url": "https://static.inaturalist.org/photos/6973322/square.jpg?1491829047"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          26172,
+          85552,
+          36982,
+          787700,
+          37763,
+          73788
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Common Five-lined Skink"
+      }
+    },
+    {
+      "count": 6,
+      "taxon": {
+        "observations_count": 26531,
+        "taxon_schemes_count": 7,
+        "ancestry": "48460/1/2/355675/26036/39532/39680/39681",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 6
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Common_snapping_turtle",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 1,
+        "atlas_id": 638,
+        "complete_species_count": null,
+        "parent_id": 39681,
+        "complete_rank": "subspecies",
+        "name": "Chelydra serpentina",
+        "rank": "species",
+        "extinct": false,
+        "id": 39682,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/493231/square.jpg?1378868682",
+          "attribution": "(c) Keegan Smith, all rights reserved",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/493231/medium.jpg?1378868682",
+          "id": 493231,
+          "license_code": null,
+          "original_dimensions": {
+            "width": 720,
+            "height": 481
+          },
+          "url": "https://static.inaturalist.org/photos/493231/square.jpg?1378868682"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          39532,
+          39680,
+          39681,
+          39682
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Snapping Turtle"
+      }
+    },
+    {
+      "count": 5,
+      "taxon": {
+        "observations_count": 70573,
+        "taxon_schemes_count": 10,
+        "ancestry": "48460/1/2/355675/3/7251/71305/9080",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Northern_cardinal",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 26016,
+        "complete_species_count": null,
+        "parent_id": 9080,
+        "complete_rank": "subspecies",
+        "name": "Cardinalis cardinalis",
+        "rank": "species",
+        "extinct": false,
+        "id": 9083,
+        "default_photo": {
+          "square_url": "https://farm3.staticflickr.com/2755/4342274222_d7c410714d_s.jpg",
+          "attribution": "(c) Jen Goellnitz, some rights reserved (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://farm3.staticflickr.com/2755/4342274222_d7c410714d.jpg",
+          "id": 29472236,
+          "license_code": "cc-by-nc",
+          "original_dimensions": null,
+          "url": "https://farm3.staticflickr.com/2755/4342274222_d7c410714d_s.jpg"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          7251,
+          71305,
+          9080,
+          9083
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "Northern Cardinal"
+      }
+    },
+    {
+      "count": 4,
+      "taxon": {
+        "observations_count": 20642,
+        "taxon_schemes_count": 8,
+        "ancestry": "48460/1/2/355675/3/7251/13547/13629",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Tufted_titmouse",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": null,
+        "complete_species_count": null,
+        "parent_id": 13629,
+        "complete_rank": "subspecies",
+        "name": "Baeolophus bicolor",
+        "rank": "species",
+        "extinct": false,
+        "id": 13632,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/898/square.jpg?1545367217",
+          "attribution": "(c) ehpien, some rights reserved (CC BY-NC-ND)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/898/medium.jpg?1545367217",
+          "id": 898,
+          "license_code": "cc-by-nc-nd",
+          "original_dimensions": {
+            "width": 1917,
+            "height": 2048
+          },
+          "url": "https://static.inaturalist.org/photos/898/square.jpg?1545367217"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          7251,
+          13547,
+          13629,
+          13632
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "Tufted Titmouse"
+      }
+    },
+    {
+      "count": 4,
+      "taxon": {
+        "observations_count": 13106,
+        "taxon_schemes_count": 10,
+        "ancestry": "48460/1/2/355675/3/19350/19728/19885",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Barred_owl",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": null,
+        "complete_species_count": null,
+        "parent_id": 19885,
+        "complete_rank": "subspecies",
+        "name": "Strix varia",
+        "rank": "species",
+        "extinct": false,
+        "id": 19893,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/10214388/square.jpg?1545911084",
+          "attribution": "(c) anonymous, certains droits réservés (CC BY-SA)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/10214388/medium.jpg?1545911084",
+          "id": 10214388,
+          "license_code": "cc-by-sa",
+          "original_dimensions": {
+            "width": 2000,
+            "height": 2000
+          },
+          "url": "https://static.inaturalist.org/photos/10214388/square.jpg?1545911084"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          19350,
+          19728,
+          19885,
+          19893
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "Barred Owl"
+      }
+    },
+    {
+      "count": 4,
+      "taxon": {
+        "observations_count": 2349,
+        "taxon_schemes_count": 5,
+        "ancestry": "48460/1/2/355675/26036/26172/85553/26504/797518/27383",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Carphophis_amoenus",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 177,
+        "complete_species_count": null,
+        "parent_id": 27383,
+        "complete_rank": "subspecies",
+        "name": "Carphophis amoenus",
+        "rank": "species",
+        "extinct": false,
+        "id": 27388,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/13472008/square.jpg?1518459786",
+          "attribution": "(c) Zach Lim, some rights reserved (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/13472008/medium.jpg?1518459786",
+          "id": 13472008,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1366
+          },
+          "url": "https://static.inaturalist.org/photos/13472008/square.jpg?1518459786"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          26172,
+          85553,
+          26504,
+          797518,
+          27383,
+          27388
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Eastern Worm Snake"
+      }
+    },
+    {
+      "count": 4,
+      "taxon": {
+        "observations_count": 786,
+        "taxon_schemes_count": 2,
+        "ancestry": "48460/1/2/355675/26036/26172/85553/26504/797520/29768",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Lampropeltis_nigra",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 2,
+        "atlas_id": 701,
+        "complete_species_count": null,
+        "parent_id": 29768,
+        "complete_rank": "subspecies",
+        "name": "Lampropeltis nigra",
+        "rank": "species",
+        "extinct": false,
+        "id": 60348,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/12050719/square.jpeg?1511726087",
+          "attribution": "(c) Tristan Clark, algunos derechos reservados (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/12050719/medium.jpeg?1511726087",
+          "id": 12050719,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1282
+          },
+          "url": "https://static.inaturalist.org/photos/12050719/square.jpeg?1511726087"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          26172,
+          85553,
+          26504,
+          797520,
+          29768,
+          60348
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Black Kingsnake"
+      }
+    }
+  ]
+}

--- a/test/sample_data/get_all_observation_species_counts_page2.json
+++ b/test/sample_data/get_all_observation_species_counts_page2.json
@@ -1,0 +1,474 @@
+{
+  "total_results": 22,
+  "page": 2,
+  "per_page": 30,
+  "results": [
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 89637,
+        "taxon_schemes_count": 9,
+        "ancestry": "48460/1/2/355675/3/7251/15977/12705",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/American_robin",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": null,
+        "complete_species_count": null,
+        "parent_id": 12705,
+        "complete_rank": "subspecies",
+        "name": "Turdus migratorius",
+        "rank": "species",
+        "extinct": false,
+        "id": 12727,
+        "default_photo": {
+          "square_url": "https://live.staticflickr.com/65535/46927069094_2a426c38ff_s.jpg",
+          "attribution": "(c) Dennis Church, some rights reserved (CC BY-NC-ND)",
+          "flags": [],
+          "medium_url": "https://live.staticflickr.com/65535/46927069094_2a426c38ff.jpg",
+          "id": 65895239,
+          "license_code": "cc-by-nc-nd",
+          "original_dimensions": null,
+          "url": "https://live.staticflickr.com/65535/46927069094_2a426c38ff_s.jpg"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          7251,
+          15977,
+          12705,
+          12727
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "American Robin"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 22380,
+        "taxon_schemes_count": 9,
+        "ancestry": "48460/1/2/355675/3/7251/14799/14800",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/White-breasted_nuthatch",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": null,
+        "complete_species_count": null,
+        "parent_id": 14800,
+        "complete_rank": "subspecies",
+        "name": "Sitta carolinensis",
+        "rank": "species",
+        "extinct": false,
+        "id": 14801,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/23268608/square.jpg?1545337571",
+          "attribution": "(c) U.S. Fish and Wildlife Service Northeast Region, einige Rechte vorbehalten ()",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/23268608/medium.jpg?1545337571",
+          "id": 23268608,
+          "license_code": null,
+          "original_dimensions": {
+            "width": 1024,
+            "height": 695
+          },
+          "url": "https://static.inaturalist.org/photos/23268608/square.jpg?1545337571"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          7251,
+          14799,
+          14800,
+          14801
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "White-breasted Nuthatch"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 4869,
+        "taxon_schemes_count": 9,
+        "ancestry": "48460/1/2/355675/3/7251/17354/17355",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "https://en.wikipedia.org/wiki/White-eyed_vireo",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": null,
+        "complete_species_count": null,
+        "parent_id": 17355,
+        "complete_rank": "subspecies",
+        "name": "Vireo griseus",
+        "rank": "species",
+        "extinct": false,
+        "id": 17408,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/2779180/square.jpg?1450211639",
+          "attribution": "(c) jalinage00, some rights reserved (CC BY-NC), uploaded by José Antonio Linage Espinosa",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/2779180/medium.jpg?1450211639",
+          "id": 2779180,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 1200,
+            "height": 1200
+          },
+          "url": "https://static.inaturalist.org/photos/2779180/square.jpg?1450211639"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          7251,
+          17354,
+          17355,
+          17408
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "White-eyed Vireo"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 26731,
+        "taxon_schemes_count": 8,
+        "ancestry": "48460/1/2/355675/3/17550/17599/18158",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "https://en.wikipedia.org/wiki/Red-bellied_woodpecker",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 3,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": null,
+        "complete_species_count": null,
+        "parent_id": 18158,
+        "complete_rank": "subspecies",
+        "name": "Melanerpes carolinus",
+        "rank": "species",
+        "extinct": false,
+        "id": 18205,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/1045438/square.jpg?1545564311",
+          "attribution": "(c) Dawn Vornholt, some rights reserved (CC BY-NC-ND)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/1045438/medium.jpg?1545564311",
+          "id": 1045438,
+          "license_code": "cc-by-nc-nd",
+          "original_dimensions": {
+            "width": 1367,
+            "height": 1827
+          },
+          "url": "https://static.inaturalist.org/photos/1045438/square.jpg?1545564311"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          3,
+          17550,
+          17599,
+          18158,
+          18205
+        ],
+        "iconic_taxon_name": "Aves",
+        "preferred_common_name": "Red-bellied Woodpecker"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 11631,
+        "taxon_schemes_count": 8,
+        "ancestry": "48460/1/2/355675/20978/20979/23540/787552/24253",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "https://en.wikipedia.org/wiki/Spring_peeper",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 508,
+        "complete_species_count": null,
+        "parent_id": 24253,
+        "name": "Pseudacris crucifer",
+        "rank": "species",
+        "extinct": false,
+        "id": 24268,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/6428345/square.jpg?1488408340",
+          "attribution": "(c) Bruce J. Mohn, some rights reserved (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/6428345/medium.jpg?1488408340",
+          "id": 6428345,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 640,
+            "height": 427
+          },
+          "url": "https://static.inaturalist.org/photos/6428345/square.jpg?1488408340"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          20979,
+          23540,
+          787552,
+          24253,
+          24268
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Spring Peeper"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 7743,
+        "taxon_schemes_count": 8,
+        "ancestry": "48460/1/2/355675/20978/26718/26720/26721",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Spotted_salamander",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 485,
+        "complete_species_count": null,
+        "parent_id": 26721,
+        "name": "Ambystoma maculatum",
+        "rank": "species",
+        "extinct": false,
+        "id": 26790,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/1640459/square.jpg?1426895381",
+          "attribution": "(c) Travis W. Reeder, some rights reserved (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/1640459/medium.jpg?1426895381",
+          "id": 1640459,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 1000,
+            "height": 667
+          },
+          "url": "https://static.inaturalist.org/photos/1640459/square.jpg?1426895381"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          26718,
+          26720,
+          26721,
+          26790
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Spotted Salamander"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 1081,
+        "taxon_schemes_count": 8,
+        "ancestry": "48460/1/2/355675/20978/26718/26909/787551/27380",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 0
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Seal_salamander",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 20978,
+        "rank_level": 10,
+        "taxon_changes_count": 0,
+        "atlas_id": 471,
+        "complete_species_count": null,
+        "parent_id": 27380,
+        "name": "Desmognathus monticola",
+        "rank": "species",
+        "extinct": false,
+        "id": 27413,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/32754486/square.jpeg?1552435833",
+          "attribution": "(c) J.D. Willson, alcuni diritti riservati (CC BY-NC)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/32754486/medium.jpeg?1552435833",
+          "id": 32754486,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1373
+          },
+          "url": "https://static.inaturalist.org/photos/32754486/square.jpeg?1552435833"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          20978,
+          26718,
+          26909,
+          787551,
+          27380,
+          27413
+        ],
+        "iconic_taxon_name": "Amphibia",
+        "preferred_common_name": "Seal Salamander"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 6470,
+        "taxon_schemes_count": 3,
+        "ancestry": "48460/1/2/355675/26036/26172/85552/36074/797562/36141",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Eastern_fence_lizard",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 1,
+        "atlas_id": 694,
+        "complete_species_count": null,
+        "parent_id": 36141,
+        "complete_rank": "subspecies",
+        "name": "Sceloporus undulatus",
+        "rank": "species",
+        "extinct": false,
+        "id": 36142,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/4753638/square.jpeg?1472877457",
+          "attribution": "(c) Matt Muir, some rights reserved (CC BY-SA)",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/4753638/medium.jpeg?1472877457",
+          "id": 4753638,
+          "license_code": "cc-by-sa",
+          "original_dimensions": {
+            "width": 2048,
+            "height": 1538
+          },
+          "url": "https://static.inaturalist.org/photos/4753638/square.jpeg?1472877457"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          26172,
+          85552,
+          36074,
+          797562,
+          36141,
+          36142
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Eastern Fence Lizard"
+      }
+    },
+    {
+      "count": 1,
+      "taxon": {
+        "observations_count": 5895,
+        "taxon_schemes_count": 7,
+        "ancestry": "48460/1/2/355675/26036/39532/39539/797526/39555",
+        "is_active": true,
+        "flag_counts": {
+          "unresolved": 0,
+          "resolved": 1
+        },
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Spiny_softshell_turtle",
+        "current_synonymous_taxon_ids": null,
+        "iconic_taxon_id": 26036,
+        "rank_level": 10,
+        "taxon_changes_count": 1,
+        "atlas_id": 622,
+        "complete_species_count": null,
+        "parent_id": 39555,
+        "complete_rank": "subspecies",
+        "name": "Apalone spinifera",
+        "rank": "species",
+        "extinct": false,
+        "id": 39556,
+        "default_photo": {
+          "square_url": "https://static.inaturalist.org/photos/179018/square.jpg",
+          "attribution": "(c) greg2, some rights reserved (CC BY-NC), uploaded by Greg Lasley",
+          "flags": [],
+          "medium_url": "https://static.inaturalist.org/photos/179018/medium.jpg",
+          "id": 179018,
+          "license_code": "cc-by-nc",
+          "original_dimensions": {
+            "width": 700,
+            "height": 467
+          },
+          "url": "https://static.inaturalist.org/photos/179018/square.jpg"
+        },
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          26036,
+          39532,
+          39539,
+          797526,
+          39555,
+          39556
+        ],
+        "iconic_taxon_name": "Reptilia",
+        "preferred_common_name": "Spiny Softshell Turtle"
+      }
+    }
+  ]
+}

--- a/test/test_node_api.py
+++ b/test/test_node_api.py
@@ -114,13 +114,19 @@ def test_get_all_observation_species_counts(requests_mock):
     requests_mock.get(
         urljoin(INAT_NODE_API_BASE_URL, "observations/species_counts"),
         [
-            {'json': load_sample_data("get_all_observation_species_counts_page1.json"),
-            'status_code': 200},
-            {'json': load_sample_data("get_all_observation_species_counts_page2.json"),
-            'status_code': 200}
-        ]
+            {
+                "json": load_sample_data("get_all_observation_species_counts_page1.json"),
+                "status_code": 200,
+            },
+            {
+                "json": load_sample_data("get_all_observation_species_counts_page2.json"),
+                "status_code": 200,
+            },
+        ],
     )
-    response = get_all_observation_species_counts(user_login="my_username", quality_grade="research")
+    response = get_all_observation_species_counts(
+        user_login="my_username", quality_grade="research"
+    )
     first_result = response[0]
     last_result = response[-1]
 

--- a/test/test_node_api.py
+++ b/test/test_node_api.py
@@ -9,6 +9,7 @@ from pyinaturalist.node_api import (
     get_observations,
     get_all_observations,
     get_observation_species_counts,
+    get_all_observation_species_counts,
     get_geojson_observations,
     get_places_by_id,
     get_places_nearby,
@@ -107,6 +108,28 @@ def test_get_observation_species_counts(requests_mock):
     assert first_result["count"] == 31
     assert first_result["taxon"]["id"] == 48484
     assert first_result["taxon"]["name"] == "Harmonia axyridis"
+
+
+def test_get_all_observation_species_counts(requests_mock):
+    requests_mock.get(
+        urljoin(INAT_NODE_API_BASE_URL, "observations/species_counts"),
+        [
+            {'json': load_sample_data("get_all_observation_species_counts_page1.json"),
+            'status_code': 200},
+            {'json': load_sample_data("get_all_observation_species_counts_page2.json"),
+            'status_code': 200}
+        ]
+    )
+    response = get_all_observation_species_counts(user_login="my_username", quality_grade="research")
+    first_result = response[0]
+    last_result = response[-1]
+
+    assert first_result["count"] == 19
+    assert first_result["taxon"]["id"] == 27805
+    assert first_result["taxon"]["name"] == "Notophthalmus viridescens"
+    assert last_result["count"] == 1
+    assert last_result["taxon"]["id"] == 39556
+    assert last_result["taxon"]["name"] == "Apalone spinifera"
 
 
 def test_get_observation_species_counts__invalid_multiple_choice_params():


### PR DESCRIPTION
Added two new functions `get_observations_species_counts` and `get_all_observations_species_counts` that utilize the iNaturalist API *observations/species_counts* endpoint (https://api.inaturalist.org/v1/docs/#!/Observations/get_observations_species_counts). I needed these and thought others might find them useful as well.

I hope this is helpful!