### PR TITLE
Add support for both file paths and file-like objects to endpoints that upload files

### DIFF
--- a/pyinaturalist/api_docs.py
+++ b/pyinaturalist/api_docs.py
@@ -3,7 +3,7 @@ Reusable template functions used for API documentation.
 Each template function contains a portion of an endpoint's request parameters, with corresponding
 type annotations and docstrings.
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Iterable
 
 from pyinaturalist.constants import (
     MultiInt,
@@ -11,6 +11,7 @@ from pyinaturalist.constants import (
     Date,
     DateTime,
     IntOrStr,
+    FileOrPath,
 )
 from pyinaturalist.request_params import MULTIPLE_CHOICE_PARAMS
 
@@ -242,7 +243,7 @@ def _create_observations_params(
     flickr_photos: MultiInt = None,
     picasa_photos: MultiStr = None,
     facebook_photos: MultiStr = None,
-    local_photos: MultiStr = None,
+    local_photos: Iterable[FileOrPath] = None,
 ):
     """
     species_guess: Equivalent to the "What did you see?" field on the observation form.
@@ -268,19 +269,17 @@ def _create_observations_params(
         their Picasa and iNat accounts connected, and the user must own the photo(s) on Picasa.
     facebook_photos: Facebook photo IDs to add as photos for this observation. User must have
         their Facebook and iNat accounts connected, and the user must own the photo on Facebook.
-    local_photos: [NOT IMPLEMENTED] Fields containing uploaded photo data. Request must have a ``Content-Type``
-        of ``"multipart"``. We recommend that you use the ``POST /observation_photos`` endpoint
-        instead.
+    local_photos: Image files, file-like objects, and/or paths for local photos to upload
     """
 
 
 def _update_observation_params(
     # _method: str = None,  # Exposed as a client-specific workaround; not needed w/ `requests`
-    ignore_photos: bool = False,
+    ignore_photos: bool = True,
 ):
     """
     ignore_photos
-        If photos exist on the observation but are missing in the request, simpy ignore them
+        If photos exist on the observation but are missing in the request, simply ignore them
         instead of deleting the missing observation photos
     """
 

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, BinaryIO, Callable, Dict, List, Union
 
 INAT_NODE_API_BASE_URL = "https://api.inaturalist.org/v1/"
 INAT_BASE_URL = "https://www.inaturalist.org"
@@ -15,8 +15,10 @@ WRITE_HTTP_METHODS = ["PATCH", "POST", "PUT", "DELETE"]
 # Type aliases
 Date = Union[date, datetime, str]
 DateTime = Union[date, datetime, str]
+FileOrPath = Union[BinaryIO, str]
 IntOrStr = Union[int, str]
 JsonResponse = Dict[str, Any]
+ListResponse = List[Dict[str, Any]]
 RequestParams = Dict[str, Any]
 MultiInt = Union[int, List[int]]
 MultiStr = Union[str, List[str]]

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -28,6 +28,7 @@ from pyinaturalist.constants import (
     THROTTLING_DELAY,
     MultiInt,
     JsonResponse,
+    RequestParams,
 )
 from pyinaturalist.exceptions import ObservationNotFound
 from pyinaturalist.forge_utils import document_request_params
@@ -98,7 +99,9 @@ def get_observation(observation_id: int, user_agent: str = None) -> JsonResponse
 
 
 @document_request_params(get_observations_params)
-def get_observations(params: Dict = None, user_agent: str = None, **kwargs) -> JsonResponse:
+def get_observations(
+    params: RequestParams = None, user_agent: str = None, **kwargs
+) -> JsonResponse:
     """Search observations.
 
     **API reference:** http://api.inaturalist.org/v1/docs/#!/Observations/get_observations
@@ -133,7 +136,7 @@ def get_observations(params: Dict = None, user_agent: str = None, **kwargs) -> J
 
 @document_request_params(get_all_observations_params)
 def get_all_observations(
-    params: Dict = None, user_agent: str = None, **kwargs
+    params: RequestParams = None, user_agent: str = None, **kwargs
 ) -> List[JsonResponse]:
     """Like :py:func:`get_observations()`, but handles pagination and returns all results in one
     call. Explicit pagination parameters will be ignored.

--- a/pyinaturalist/rest_api.py
+++ b/pyinaturalist/rest_api.py
@@ -3,7 +3,7 @@ Code used to access the (read/write, but slow) Rails based API of iNaturalist
 See: https://www.inaturalist.org/pages/api+reference
 """
 from time import sleep
-from typing import Dict, Any, List, BinaryIO, Union
+from typing import Dict, Any, List, Union
 
 from urllib.parse import urljoin
 
@@ -15,7 +15,14 @@ from pyinaturalist.api_docs import (
     update_observation_params,
     delete_observation_params,
 )
-from pyinaturalist.constants import THROTTLING_DELAY, INAT_BASE_URL
+from pyinaturalist.constants import (
+    THROTTLING_DELAY,
+    INAT_BASE_URL,
+    FileOrPath,
+    JsonResponse,
+    ListResponse,
+    RequestParams,
+)
 from pyinaturalist.exceptions import AuthenticationError, ObservationNotFound
 from pyinaturalist.api_requests import delete, get, post, put
 from pyinaturalist.forge_utils import document_request_params
@@ -23,6 +30,8 @@ from pyinaturalist.request_params import (
     OBSERVATION_FORMATS,
     REST_OBS_ORDER_BY_PROPERTIES,
     check_deprecated_params,
+    ensure_file_obj,
+    ensure_file_objs,
     validate_multiple_choice_param,
 )
 from pyinaturalist.response_format import convert_lat_long_to_float
@@ -137,7 +146,7 @@ def get_observations(user_agent: str = None, **kwargs) -> Union[List, str]:
 
 
 @document_request_params(get_observation_fields_params)
-def get_observation_fields(user_agent: str = None, **kwargs) -> List[Dict[str, Any]]:
+def get_observation_fields(user_agent: str = None, **kwargs) -> ListResponse:
     """Search observation fields. Observation fields are basically typed data fields that
     users can attach to observation.
 
@@ -156,7 +165,7 @@ def get_observation_fields(user_agent: str = None, **kwargs) -> List[Dict[str, A
     Returns:
         Observation fields as a list of dicts
     """
-    kwargs = check_deprecated_params(kwargs)
+    kwargs = check_deprecated_params(**kwargs)
     response = get(
         "{base_url}/observation_fields.json".format(base_url=INAT_BASE_URL),
         params=kwargs,
@@ -166,7 +175,7 @@ def get_observation_fields(user_agent: str = None, **kwargs) -> List[Dict[str, A
 
 
 @document_request_params(get_all_observation_fields_params)
-def get_all_observation_fields(**kwargs) -> List[Dict[str, Any]]:
+def get_all_observation_fields(**kwargs) -> ListResponse:
     """
     Like :py:func:`.get_observation_fields()`, but handles pagination for you.
 
@@ -198,7 +207,7 @@ def put_observation_field_values(
     value: Any,
     access_token: str,
     user_agent: str = None,
-) -> Dict[str, Any]:
+) -> JsonResponse:
     # TODO: Also implement a put_or_update_observation_field_values() that deletes then recreates the field_value?
     # TODO: Write example use in docstring.
     # TODO: Return some meaningful exception if it fails because the field is already set.
@@ -258,11 +267,11 @@ def put_observation_field_values(
 
 
 # TODO: Implement `observation_field_values_attributes`, and simplify nested data structures
-# TODO: implement `local_photos` and support both local file path(s) and object(s)
+# TODO: more thorough usage example
 @document_request_params(create_observations_params)
 def create_observations(
-    params: Dict[str, Dict[str, Any]], access_token: str, user_agent: str = None, **kwargs
-) -> List[Dict[str, Any]]:
+    params: RequestParams = None, access_token: str = None, user_agent: str = None, **kwargs
+) -> ListResponse:
     """Create one or more observations.
 
     **API reference:** https://www.inaturalist.org/pages/api+reference#post-observations
@@ -272,6 +281,7 @@ def create_observations(
         >>> create_observations(
         >>>     access_token=token,
         >>>     species_guess='Pieris rapae',
+        >>>     local_photos='~/observation_photos/2020_09_01_14003156.jpg',
         >>> )
 
         .. admonition:: Example Response
@@ -298,16 +308,17 @@ def create_observations(
     TODO investigate: according to the doc, we should be able to pass multiple observations (in an array, and in
     renaming observation to observations, but as far as I saw they are not created (while a status of 200 is returned)
     """
-    # This is the one Boolean parameter that's specified as an int, for some reason
-    if "ignore_photos" in kwargs:
-        kwargs["ignore_photos"] = int(kwargs["ignore_photos"])
-    kwargs = check_deprecated_params(kwargs)
-    if "observation" not in kwargs:
-        kwargs = {"observation": kwargs}
+    # Accept either top-level params (like most other endpoints)
+    # or nested params (like the iNat API actually accepts)
+    if "observation" in kwargs:
+        kwargs.update(kwargs.pop("observation"))
+    kwargs = check_deprecated_params(params, **kwargs)
+    if "local_photos" in kwargs:
+        kwargs["local_photos"] = ensure_file_objs(kwargs["local_photos"])
 
     response = post(
         url="{base_url}/observations.json".format(base_url=INAT_BASE_URL),
-        json=params,
+        json={"observation": kwargs},
         access_token=access_token,
         user_agent=user_agent,
     )
@@ -317,12 +328,23 @@ def create_observations(
 
 @document_request_params(update_observation_params)
 def update_observation(
-    observation_id: int, params: Dict[str, Any], access_token: str, user_agent: str = None, **kwargs
-) -> List[Dict[str, Any]]:
+    observation_id: int,
+    params: RequestParams = None,
+    access_token: str = None,
+    user_agent: str = None,
+    **kwargs
+) -> ListResponse:
     """
     Update a single observation.
 
     **API reference:** https://www.inaturalist.org/pages/api+reference#put-observations-id
+
+    .. note::
+
+        Unlike the underlying REST API endpoint, this function will **not** delete any existing
+        photos from your observation if not specified in ``local_photos``. If you want this to
+        behave the same as the REST API and you do want to delete photos, call with
+        ``ignore_photos=False``.
 
     Example:
 
@@ -330,7 +352,6 @@ def update_observation(
         >>> update_observation(
         >>>     17932425,
         >>>     access_token=token,
-        >>>     ignore_photos=1,
         >>>     description="updated description!",
         >>> )
 
@@ -347,15 +368,24 @@ def update_observation(
         :py:exc:`requests.HTTPError`, if the call is not successful. iNaturalist returns an
             error 410 if the observation doesn't exists or belongs to another user.
     """
+    # Accept either top-level params (like most other endpoints)
+    # or nested params (like the iNat API actually accepts)
+    if "observation" in kwargs:
+        kwargs.update(kwargs.pop("observation"))
+    kwargs = check_deprecated_params(params, **kwargs)
+    if "local_photos" in kwargs:
+        kwargs["local_photos"] = ensure_file_objs(kwargs["local_photos"])
+
+    # This is the one Boolean parameter that's specified as an int, for some reason.
+    # Also, set it to True if not specified, which seems like much saner default behavior.
     if "ignore_photos" in kwargs:
         kwargs["ignore_photos"] = int(kwargs["ignore_photos"])
-    kwargs = check_deprecated_params(kwargs)
-    if "observation" not in kwargs:
-        kwargs = {"observation": kwargs}
+    else:
+        kwargs["ignore_photos"] = 1
 
     response = put(
         url="{base_url}/observations/{id}.json".format(base_url=INAT_BASE_URL, id=observation_id),
-        json=params,
+        json={"observation": kwargs},
         access_token=access_token,
         user_agent=user_agent,
     )
@@ -363,22 +393,24 @@ def update_observation(
     return response.json()
 
 
-# TODO: Support both local file path(s) and object(s)
 def add_photo_to_observation(
     observation_id: int,
-    file_object: BinaryIO,
+    photo: FileOrPath,
     access_token: str,
     user_agent: str = None,
 ):
-    """Upload a picture and assign it to an existing observation.
+    """Upload a local photo and assign it to an existing observation.
 
     **API reference:** https://www.inaturalist.org/pages/api+reference#post-observation_photos
 
     Example:
 
         >>> token = get_access_token('...')
-        >>> with open('~/observation_photos/2020_09_01_14003156.jpg', 'rb') as f:
-        >>>     add_photo_to_observation(1234, f, access_token=token)
+        >>> add_photo_to_observation(
+        >>>     1234,
+        >>>     '~/observation_photos/2020_09_01_14003156.jpg',
+        >>>     access_token=token,
+        >>> )
 
         .. admonition:: Example Response
             :class: toggle
@@ -388,22 +420,19 @@ def add_photo_to_observation(
 
     Args:
         observation_id: the ID of the observation
-        file_object: a file-like object for the picture
+        photo: An image file, file-like object, or path
         access_token: the access token, as returned by :func:`get_access_token()`
         user_agent: a user-agent string that will be passed to iNaturalist.
 
     Returns:
         Information about the newly created photo
     """
-    data = {"observation_photo[observation_id]": observation_id}
-    file_data = {"file": file_object}
-
     response = post(
         url="{base_url}/observation_photos".format(base_url=INAT_BASE_URL),
         access_token=access_token,
+        data={"observation_photo[observation_id]": observation_id},
+        files={"file": ensure_file_obj(photo)},
         user_agent=user_agent,
-        data=data,
-        files=file_data,
     )
 
     return response.json()
@@ -420,7 +449,7 @@ def delete_observation(observation_id: int, access_token: str = None, user_agent
     Example:
 
         >>> token = get_access_token('...')
-        >>> delete_observation(17932425, access_token=token)
+        >>> delete_observation(17932425, token)
 
     Returns:
         If successful, no response is returned from this endpoint

--- a/test/test_request_params.py
+++ b/test/test_request_params.py
@@ -1,6 +1,8 @@
 import pytest
 from datetime import date, datetime
 from dateutil.tz import gettz
+from io import BytesIO
+from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
 from pyinaturalist.request_params import (
@@ -8,6 +10,7 @@ from pyinaturalist.request_params import (
     convert_bool_params,
     convert_datetime_params,
     convert_list_params,
+    ensure_file_obj,
     strip_empty_params,
     validate_ids,
     validate_multiple_choice_param,
@@ -60,6 +63,20 @@ def test_convert_list_params():
     params = convert_list_params(TEST_PARAMS)
     assert params["preferred_place_id"] == "1,2"
     assert params["rank"] == "phylum,class"
+
+
+def test_ensure_file_obj__file_path():
+    with NamedTemporaryFile() as temp:
+        temp.write(b"test content")
+        temp.seek(0)
+
+        file_obj = ensure_file_obj(temp.name)
+        assert file_obj.read() == b"test content"
+
+
+def test_ensure_file_obj__file_obj():
+    file_obj = BytesIO(b"test content")
+    assert ensure_file_obj(file_obj) == file_obj
 
 
 def test_strip_empty_params():

--- a/test/test_rest_api.py
+++ b/test/test_rest_api.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from io import BytesIO
+from unittest.mock import patch
 
 import pytest
 from requests import HTTPError
@@ -176,14 +177,24 @@ def test_update_observation(requests_mock):
 
     params = {
         "ignore_photos": 1,
-        "observation": {"description": "updated description v2 !"},
+        "description": "updated description v2 !",
     }
-    r = update_observation(observation_id=17932425, access_token="valid token", params=params)
+    r = update_observation(observation_id=17932425, access_token="valid token", **params)
 
     # If all goes well we got a single element representing the updated observation, enclosed in a list.
     assert len(r) == 1
     assert r[0]["id"] == 17932425
     assert r[0]["description"] == "updated description v2 !"
+
+
+@patch("pyinaturalist.rest_api.ensure_file_objs")
+@patch("pyinaturalist.rest_api.put")
+def test_update_observation__local_photo(put, ensure_file_objs):
+    update_observation(1234, access_token="token", local_photos="photo.jpg")
+
+    # Make sure local_photos is replaced with the output of ensure_file_objs
+    called_params = put.call_args[1]["json"]["observation"]
+    assert called_params["local_photos"] == ensure_file_objs.return_value
 
 
 def test_update_nonexistent_observation(requests_mock):
@@ -196,11 +207,11 @@ def test_update_nonexistent_observation(requests_mock):
 
     params = {
         "ignore_photos": 1,
-        "observation": {"description": "updated description v2 !"},
+        "description": "updated description v2 !",
     }
 
     with pytest.raises(HTTPError) as excinfo:
-        update_observation(observation_id=999999999, access_token="valid token", params=params)
+        update_observation(observation_id=999999999, access_token="valid token", **params)
     assert excinfo.value.response.status_code == 410
     assert excinfo.value.response.json() == {"error": "Cette observation n’existe plus."}
 
@@ -215,14 +226,14 @@ def test_update_observation_not_mine(requests_mock):
 
     params = {
         "ignore_photos": 1,
-        "observation": {"description": "updated description v2 !"},
+        "description": "updated description v2 !",
     }
 
     with pytest.raises(HTTPError) as excinfo:
         update_observation(
             observation_id=16227955,
             access_token="valid token for another user",
-            params=params,
+            **params,
         )
     assert excinfo.value.response.status_code == 410
     assert excinfo.value.response.json() == {"error": "Cette observation n’existe plus."}
@@ -235,26 +246,28 @@ def test_create_observation(requests_mock):
         status_code=200,
     )
 
-    params = {
-        "observation": {"species_guess": "Pieris rapae"},
-    }
-
-    r = create_observations(params=params, access_token="valid token")
+    r = create_observations(species_guess="Pieris rapae", access_token="valid token")
     assert len(r) == 1  # We added a single one
-    assert (
-        r[0]["latitude"] is None
-    )  # We have the field, but it's none since we didn't submitted anything
+    assert r[0]["latitude"] is None
     assert r[0]["taxon_id"] == 55626  # Pieris Rapae @ iNaturalist
+
+
+@patch("pyinaturalist.rest_api.ensure_file_objs")
+@patch("pyinaturalist.rest_api.post")
+def test_create_observation__local_photo(post, ensure_file_objs):
+    create_observations(access_token="token", local_photos="photo.jpg")
+
+    # Make sure local_photos is replaced with the output of ensure_file_objs
+    called_params = post.call_args[1]["json"]["observation"]
+    assert called_params["local_photos"] == ensure_file_objs.return_value
 
 
 def test_create_observation_fail(requests_mock):
     params = {
-        "observation": {
-            "species_guess": "Pieris rapae",
-            # Some invalid data so the observation is rejected...
-            "observed_on_string": (datetime.now() + timedelta(days=1)).isoformat(),
-            "latitude": 200,
-        }
+        "species_guess": "Pieris rapae",
+        # Some invalid data so the observation is rejected...
+        "observed_on_string": (datetime.now() + timedelta(days=1)).isoformat(),
+        "latitude": 200,
     }
 
     requests_mock.post(
@@ -264,7 +277,7 @@ def test_create_observation_fail(requests_mock):
     )
 
     with pytest.raises(HTTPError) as excinfo:
-        create_observations(params=params, access_token="valid token")
+        create_observations(access_token="valid token", **params)
     assert excinfo.value.response.status_code == 422
     assert "errors" in excinfo.value.response.json()  # iNat also give details about the errors
 


### PR DESCRIPTION
Closes #57 

Applies to the following functions:
- [x] `rest_api.add_photo_to_observation()`
- [x] `rest_api.create_observations()`
- [x] `rest_api.update_observation()`

Other tasks:
- [x] Update docs
- [x] Update unit tests