### PR TITLE
Add documentation to summarize iNaturalist API endpoints and pyinaturalist implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,18 @@ are implemented, including:
 * Text search autocompletion for species and places
 
 See below for some examples,
-see [Reference](https://pyinaturalist.readthedocs.io/en/latest/reference.html) for a complete list, and
+see [Endpoints](https://pyinaturalist.readthedocs.io/en/latest/endpoints.html) for a complete list of implemented endpoints, and
 see [Issues](https://github.com/niconoe/pyinaturalist/issues) for planned & proposed features.
+
 More endpoints will continue to be added as they are needed.
 Please **create an issue** if there is an endpoint you would like to have added, and **PRs are welcome!**
 
 **Note:**
 
-The two iNaturalist APIs expose a combined total of 103 endpoints\*. Many of these are primarily for
-internal use by the iNaturalist web application and mobile apps, and are unlikely to be added unless
-there are specific use cases for them.
+The two iNaturalist APIs expose a combined total of 103 endpoints\*. Some of these are generally
+useful and could potentially be added to pyinaturalist, but many others are primarily for
+internal use by the iNaturalist web application and mobile apps, and are unlikely to be added
+unless there are specific use cases for them.
 
 \*As of 2020-10-01: 37 in REST API, 65 in Node API, and 1 undocumented 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,4 +126,5 @@ def patch_automodapi(app):
     """
     from sphinx_automodapi import automodsumm
     from sphinx_automodapi.utils import find_mod_objs
+
     automodsumm.find_mod_objs = lambda *args: find_mod_objs(args[0], onlylocals=True)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ project = "pyinaturalist"
 copyright = "2020, Nicolas Noé"
 needs_sphinx = "3.0"
 master_doc = "index"
-source_suffix = [".md", ".rst"]
+source_suffix = [".rst", ".md"]
 version = release = __version__
 html_static_path = ["_static"]
 templates_path = ["_templates"]
@@ -38,6 +38,8 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
+    "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.smart_resolver",
     "sphinxcontrib.apidoc",
     "m2r2",
 ]
@@ -51,6 +53,12 @@ intersphinx_mapping = {
 napoleon_google_docstring = True
 napoleon_include_private_with_doc = False
 napoleon_include_special_with_doc = False
+
+# Options for automodapi
+automodsumm_inherited_members = False
+autosummary_imported_members = False
+numpydoc_show_class_members = False
+
 
 # Use apidoc to auto-generate rst sources
 # Added here instead of instead of in Makefile so it will be used by ReadTheDocs
@@ -90,6 +98,7 @@ def setup(app):
         * https://github.com/sphinx-contrib/apidoc
     """
     app.connect("builder-inited", make_symlinks)
+    app.connect("builder-inited", patch_automodapi)
     app.add_css_file("collapsible_container.css")
 
 
@@ -108,3 +117,13 @@ def make_symlink(src, dest):
     makedirs(dirname(dest), exist_ok=True)
     if not exists(dest):
         symlink(src, dest)
+
+
+def patch_automodapi(app):
+    """Monkey-patch the automodapi extension to exclude imported members.
+
+    https://github.com/astropy/sphinx-automodapi/blob/master/sphinx_automodapi/automodsumm.py#L135
+    """
+    from sphinx_automodapi import automodsumm
+    from sphinx_automodapi.utils import find_mod_objs
+    automodsumm.find_mod_objs = lambda *args: find_mod_objs(args[0], onlylocals=True)

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: implemented_endpoints.md

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1,1 +1,28 @@
-.. mdinclude:: implemented_endpoints.md
+Implemented Endpoints
+=====================
+
+
+Pyinaturalist functions
+----------------------------------------
+Below is a list of all API functions provided by pyinaturalist.
+Note that some endpoints have more than one function associated with them.
+
+Node-based API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodsumm:: pyinaturalist.node_api
+    :functions-only:
+    :nosignatures:
+
+Rails-based API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodsumm:: pyinaturalist.rest_api
+    :functions-only:
+    :nosignatures:
+
+
+All iNaturalist endpoints
+----------------------------------------
+.. Writing the table in markdown because markdown table syntax is much more sane than rst
+
+.. mdinclude:: endpoints_table.md
+    :start-line: 1

--- a/docs/endpoints_table.md
+++ b/docs/endpoints_table.md
@@ -1,8 +1,9 @@
-# Implemented Endpoints
-Here is a complete list of iNaturalist endpoints, and the subset of them that have been implemented
-in pyinaturalist.
+## Implemented Endpoints
+Below is a complete list of iNaturalist API endpoints, and the subset of them that have been
+implemented in pyinaturalist.
 
-## Node-based API
+### Node-based API
+For full documentation, see: http://api.inaturalist.org/v1/docs/
 
 Method            | Endpoint                                    | Implemented
 ------            | ------                                      | ------
@@ -111,7 +112,8 @@ GET               | /points/{zoom}/{x}/{y}.grid.json            |
 POST              | /photos                                     |
                   
 
-## Rails-Based API
+### Rails-Based API
+For full documentation, see: https://www.inaturalist.org/pages/api+reference
 
 Method            | Endpoint                                    | Implemented
 ------            | ------                                      | ------

--- a/docs/implemented_endpoints.md
+++ b/docs/implemented_endpoints.md
@@ -1,0 +1,153 @@
+# Implemented Endpoints
+Here is a complete list of iNaturalist endpoints, and the subset of them that have been implemented
+in pyinaturalist.
+
+## Node-based API
+
+Method            | Endpoint                                    | Implemented
+------            | ------                                      | ------
+POST              | /annotations                                |
+DELETE            | /annotations/{id}                           |
+POST              | /votes/vote/annotation/{id}                 |
+DELETE            | /votes/unvote/annotation/{id}               |
+POST              | /comments                                   |
+DELETE            | /comments/{id}                              |
+PUT               | /comments/{id}                              |
+GET               | /controlled_terms                           |
+GET               | /controlled_terms/for_taxon                 |
+POST              | /flags                                      |
+DELETE            | /flags/{id}                                 |
+PUT               | /flags/{id}                                 |
+DELETE            | /identifications/{id}                       |
+GET               | /identifications/{id}                       |
+PUT               | /identifications/{id}                       |
+GET               | /identifications                            |
+POST              | /identifications                            |
+GET               | /identifications/categories                 |
+GET               | /identifications/species_counts             |
+GET               | /identifications/identifiers                |
+GET               | /identifications/observers                  |
+GET               | /identifications/recent_taxa                |
+GET               | /identifications/similar_species            |
+GET               | /messages                                   |
+POST              | /messages                                   |
+DELETE            | /messages/{id}                              |
+GET               | /messages/{id}                              |
+GET               | /messages/unread                            |
+DELETE            | /observation_field_values/{id}              |
+PUT               | /observation_field_values/{id}              |
+POST              | /observation_field_values                   |
+DELETE            | /observation_photos/{id}                    |
+PUT               | /observation_photos/{id}                    |
+POST              | /observation_photos                         |
+DELETE            | /observations/{id}                          |
+GET               | /observations/{id}                          | yes
+PUT               | /observations/{id}                          |
+POST              | /observations/{id}/fave                     |
+DELETE            | /observations/{id}/unfave                   |
+POST              | /observations/{id}/review                   |
+POST              | /observations/{id}/unreview                 |
+GET               | /observations/{id}/subscriptions            |
+DELETE            | /observations/{id}/quality/{metric}         |
+POST              | /observations/{id}/quality/{metric}         |
+GET               | /observations/{id}/taxon_summary            |
+POST              | /subscriptions/observation/{id}/subscribe   |
+POST              | /votes/vote/observation/{id}                |
+DELETE            | /votes/unvote/observation/{id}              |
+GET               | /observations                               |
+POST              | /observations                               |
+GET               | /observations/deleted                       |
+GET               | /observations/histogram                     |
+GET               | /observations/identifiers                   |
+GET               | /observations/observers                     |
+GET               | /observations/popular_field_values          |
+GET               | /observations/species_counts                | yes
+GET               | /observations/updates                       |
+PUT               | /observations/{id}/viewed_updates           |
+GET               | /places/{id}                                | yes
+GET               | /places/autocomplete                        | yes
+GET               | /places/nearby                              | yes
+GET               | /posts                                      |
+POST              | /posts                                      |
+DELETE            | /posts/{id}                                 |
+PUT               | /posts/{id}                                 |
+GET               | /posts/for_user                             |
+DELETE            | /project_observations/{id}                  |
+PUT               | /project_observations/{id}                  |
+POST              | /project_observations                       |
+GET               | /projects                                   | yes
+GET               | /projects/{id}                              | yes
+POST              | /projects/{id}/join                         |
+DELETE            | /projects/{id}/leave                        |
+GET               | /projects/{id}/members                      |
+GET               | /projects/{id}/subscriptions                |
+POST              | /projects/{id}/add                          |
+DELETE            | /projects/{id}/remove                       |
+GET               | /projects/autocomplete                      |
+POST              | /subscriptions/project/{id}/subscribe       |
+GET               | /search                                     |
+GET               | /taxa/{id}                                  | yes
+GET               | /taxa                                       | yes
+GET               | /taxa/autocomplete                          | yes
+GET               | /users/{id}                                 |
+PUT               | /users/{id}                                 |
+GET               | /users/{id}/projects                        |
+GET               | /users/autocomplete                         |
+GET               | /users/me                                   |
+DELETE            | /users/{id}/mute                            |
+POST              | /users/{id}/mute                            |
+PUT               | /users/update_session                       |
+GET               | /colored_heatmap/{zoom}/{x}/{y}.png         |
+GET               | /grid/{zoom}/{x}/{y}.png                    |
+GET               | /heatmap/{zoom}/{x}/{y}.png                 |
+GET               | /points/{zoom}/{x}/{y}.png                  |
+GET               | /places/{place_id}/{zoom}/{x}/{y}.png       |
+GET               | /taxon_places/{taxon_id}/{zoom}/{x}/{y}.png |
+GET               | /taxon_ranges/{taxon_id}/{zoom}/{x}/{y}.png |
+GET               | /colored_heatmap/{zoom}/{x}/{y}.grid.json   |
+GET               | /grid/{zoom}/{x}/{y}.grid.json              |
+GET               | /heatmap/{zoom}/{x}/{y}.grid.json           |
+GET               | /points/{zoom}/{x}/{y}.grid.json            |
+POST              | /photos                                     |
+                  
+
+## Rails-Based API
+
+Method            | Endpoint                                    | Implemented
+------            | ------                                      | ------
+POST              | /comments                                   |
+PUT               | /comments/{id}                              |
+DELETE            | /comments/{id}                              |
+POST              | /identifications                            |
+PUT               | /identifications/{id}                       |
+DELETE            | /identifications/{id}                       |
+GET               | /observations                               | yes
+POST              | /observations                               | yes
+GET               | /observations/{id}                          | yes
+PUT               | /observations/{id}                          | yes
+DELETE            | /observations/{id}                          | yes
+POST              | /observations/{id}/quality/:metric          |
+DELETE            | /observations/{id}/quality/:metric          |
+PUT               | /observations/{id}/viewed_updates           |
+GET               | /observations/:username                     |
+GET               | /observations/project/{id}                  |
+GET               | /observations/taxon_stats                   |
+GET               | /observations/user_stats                    |
+GET               | /observation_fields                         | yes
+POST              | /observation_field_values                   |
+PUT               | /observation_field_values/{id}              | yes
+DELETE            | /observation_field_values/{id}              |
+POST              | /observation_photos                         | yes
+GET               | /places                                     |
+GET               | /projects                                   |
+GET               | /projects/{id}                              |
+GET               | /projects/{id}/contributors.widget          |
+GET               | /projects/user/:login                       |
+GET               | /projects/{id}/members                      |
+POST              | /projects/{id}/join                         |
+DELETE            | /projects/{id}/leave                        |
+POST              | /project_observations                       |
+POST              | /users                                      |
+PUT               | /users/{id}                                 |
+GET               | /users/edit                                 |
+GET               | /users/new_updates                          |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents
    :maxdepth: 2
 
    general_usage
+   endpoints
    reference
    contributing
    authors

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -29,16 +29,3 @@ Pyinaturalist provides functions to use both of those APIs.
     :glob:
 
     modules/*[!i]
-
-
-All Node API functions
-----------------------
-
-.. automodsumm:: pyinaturalist.node_api
-    :functions-only:
-
-All REST API functions
-----------------------
-
-.. automodsumm:: pyinaturalist.node_api
-    :functions-only:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -18,6 +18,7 @@ Pyinaturalist provides functions to use both of those APIs.
 .. toctree::
     :caption: API Documentation
     :glob:
+    :titlesonly:
 
     modules/*_api
 
@@ -28,3 +29,16 @@ Pyinaturalist provides functions to use both of those APIs.
     :glob:
 
     modules/*[!i]
+
+
+All Node API functions
+----------------------
+
+.. automodsumm:: pyinaturalist.node_api
+    :functions-only:
+
+All REST API functions
+----------------------
+
+.. automodsumm:: pyinaturalist.node_api
+    :functions-only:

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -3,6 +3,14 @@ Code to access the (read-only, but fast) Node based public iNaturalist API
 See: http://api.inaturalist.org/v1/docs/
 
 Most recent API version tested: 1.3.0
+
+Functions
+---------
+
+.. automodsumm:: pyinaturalist.node_api
+    :functions-only:
+    :nosignatures:
+
 """
 from logging import getLogger
 from time import sleep

--- a/pyinaturalist/rest_api.py
+++ b/pyinaturalist/rest_api.py
@@ -1,6 +1,14 @@
 """
 Code used to access the (read/write, but slow) Rails based API of iNaturalist
 See: https://www.inaturalist.org/pages/api+reference
+
+Functions
+---------
+
+.. automodsumm:: pyinaturalist.node_api
+    :functions-only:
+    :nosignatures:
+
 """
 from time import sleep
 from typing import Dict, Any, List, Union

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,13 @@ extras_require = {
     "build": ["coveralls", "tox-travis"],
     # Packages used for documentation builds
     "docs": [
+        "m2r2",
         "python-forge",
         "Sphinx>=3.0",
-        "sphinx-rtd-theme",
         "sphinx-autodoc-typehints",
+        "sphinx-automodapi",
+        "sphinx-rtd-theme",
         "sphinxcontrib-apidoc",
-        "m2r2",
     ],
     # Packages used for testing both locally and in CI jobs
     "test": [


### PR DESCRIPTION
Closes #64 

* Added a complete table with details on implemented and unimplemented endpoints
* Used [shpinx-automodapi](https://github.com/astropy/sphinx-automodapi) to generate summary sections for `node_api` and `rest_api` modules
    * **Note:** This required some monkey-patching to get this to work the way I wanted. I opened an issue here, and may contribute a PR if I get a response: https://github.com/astropy/sphinx-automodapi/issues/119
