### PR TITLE
Apply global rate limits to API requests

### DIFF
--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -12,6 +12,7 @@ PHOTO_BASE_URL = 'https://static.inaturalist.org/photos'
 KEYRING_KEY = '/inaturalist'
 PER_PAGE_RESULTS = 200  # Default number of records per page for paginated queries
 THROTTLING_DELAY = 1.0  # Delay between paginated queries, in seconds
+MAX_DELAY = 60  # Maximum time to wait for rate-limiting before aborting
 
 # Toggle dry-run mode: this will run and log mock HTTP requests instead of real ones
 DRY_RUN_ENABLED = False  # Mock all requests, including GET

--- a/pyinaturalist/exceptions.py
+++ b/pyinaturalist/exceptions.py
@@ -11,3 +11,7 @@ class ObservationNotFound(HTTPError):
 
 class TaxonNotFound(HTTPError):
     pass
+
+
+class TooManyRequests(HTTPError):
+    """Error raised for either a 429 response, or pre-emptively before we reach the rate limit"""

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'keyring~=21.4.0',
-        'pyrate-limiter; python_version>="3.7"',
+        'pyrate-limiter>=2.1.0; python_version>="3.7"',
         'python-dateutil>=2.0',
         'python-forge',
         'requests~=2.25.0',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'keyring~=21.4.0',
-        'pyrate-limiter',
+        'pyrate-limiter; python_version>="3.7"',
         'python-dateutil>=2.0',
         'python-forge',
         'requests~=2.25.0',

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'keyring~=21.4.0',
+        'pyrate-limiter',
         'python-dateutil>=2.0',
         'python-forge',
         'requests~=2.25.0',

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -1,11 +1,22 @@
 import pytest
-from unittest.mock import patch
+from sys import version_info
+from unittest.mock import MagicMock, patch
 
 import pyinaturalist
-from pyinaturalist.api_requests import MOCK_RESPONSE, delete, get, post, put, request
-
+from pyinaturalist.api_requests import (
+    MOCK_RESPONSE,
+    apply_rate_limit,
+    delete,
+    get,
+    post,
+    put,
+    request,
+)
 
 # Just test that the wrapper methods call requests.request with the appropriate HTTP method
+from pyinaturalist.exceptions import TooManyRequests
+
+
 @pytest.mark.parametrize(
     'http_func, http_method',
     [(delete, 'DELETE'), (get, 'GET'), (post, 'POST'), (put, 'PUT')],
@@ -120,3 +131,47 @@ def test_request_dry_run_disabled(requests_mock):
     requests_mock.get('http://url', json={'results': ['response object']}, status_code=200)
 
     assert request('GET', 'http://url').json() == real_response
+
+
+@pytest.mark.skipif(version_info < (3, 7), reason="Requires python 3.7+")
+@patch('pyinaturalist.api_requests.sleep')
+def test_apply_rate_limit(mock_sleep):
+    from pyrate_limiter import Duration, Limiter, RequestRate
+
+    limiter = Limiter(RequestRate(60, Duration.MINUTE))
+    mock_func = MagicMock()
+
+    for i in range(70):
+        with apply_rate_limit(limiter, bucket='pytest-1'):
+            mock_func()
+
+    # With 70 requests and a limit of 60/minute, there should be a delay for the final 10 requests
+    assert mock_func.call_count == 70
+    assert mock_sleep.call_count == 10
+
+
+@pytest.mark.skipif(version_info < (3, 7), reason="Requires python 3.7+")
+@patch('pyinaturalist.api_requests.sleep')
+def test_apply_rate_limit__exceeds_max_delay(mock_sleep):
+    from pyrate_limiter import Duration, Limiter, RequestRate
+
+    limiter = Limiter(RequestRate(60, Duration.MINUTE))
+    mock_func = MagicMock()
+
+    for i in range(60):
+        with apply_rate_limit(limiter, bucket='pytest-2', max_delay=5):
+            mock_func()
+
+    # After reaching the rate limit, the next request should result in a long enough delay to abort
+    with pytest.raises(TooManyRequests):
+        with apply_rate_limit(limiter, bucket='pytest-2', max_delay=5):
+            mock_func()
+
+
+@patch('pyinaturalist.api_requests.sleep')
+def test_apply_rate_limit__no_limiter(mock_sleep):
+    for i in range(70):
+        with apply_rate_limit(None):
+            pass
+
+    assert mock_sleep.call_count == 0


### PR DESCRIPTION
Closes #105 

This adds [pyrate-limiter](https://github.com/vutran1710/PyrateLimiter) as a dependency (python 3.7+ only). For python 3.6, the extra dependency is not installed and rate-limiting will not be applied.

With the feature added in https://github.com/vutran1710/PyrateLimiter/issues/19, we can wait the exact time until the next request, or abort the request if the wait time is too long.