### PR TITLE
Some request parameter improvements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,18 @@
 ### New Endpoints
 * Added new functions for **Identifications** endpoints: `get_identifications()` and `get_identifications_by_id()`
 
+### Modified Endpoints
+* Added `count_only=True` as an alias for `per_page=0` (to get only result counts).
+  This applies to all functions that support pagination:
+  * `node_api.get_identifications()`
+  * `node_api.get_observations()`
+  * `node_api.get_observation_species_counts()`
+  * `node_api.get_observation_observers()`
+  * `node_api.get_observation_identifiers()`
+  * `node_api.get_projects()`
+  * `rest_api.get_observations()`
+  * `rest_api.get_observation_fields()`
+
 ### Other Changes
 * Added global rate-limiting to stay within the rates suggested in
   [API Recommended Practices](https://www.inaturalist.org/pages/api+recommended+practices)

--- a/pyinaturalist/api_docs.py
+++ b/pyinaturalist/api_docs.py
@@ -529,6 +529,7 @@ def _pagination(
     per_page: int = None,
     order: str = None,
     order_by: str = None,
+    count_only: bool = None,
 ):
     """
     page: Page number of results to return
@@ -536,6 +537,7 @@ def _pagination(
         unless otherwise noted
     order: Sort order
     order_by: Field to sort on
+    count_only: Only return a count of results; alias for ``per_page=0``
     """
 
 

--- a/pyinaturalist/api_requests.py
+++ b/pyinaturalist/api_requests.py
@@ -1,4 +1,4 @@
-""" Some common functions for HTTP requests used by both the Node and REST API modules """
+"""Some common functions for HTTP requests used by all API modules"""
 import threading
 from contextlib import contextmanager
 from logging import getLogger

--- a/pyinaturalist/node_api.py
+++ b/pyinaturalist/node_api.py
@@ -170,7 +170,7 @@ def get_identifications_by_id(identification_id: MultiInt, user_agent: str = Non
 
 
 @document_request_params([docs._identification_params, docs._pagination, docs._only_id])
-def get_identifications(user_agent: str = None, **params) -> JsonResponse:
+def get_identifications(**params) -> JsonResponse:
     """Search identifications.
 
     **API reference:** https://api.inaturalist.org/v1/docs/#!/Identifications/get_identifications
@@ -192,7 +192,7 @@ def get_identifications(user_agent: str = None, **params) -> JsonResponse:
         Response dict containing identification records
     """
     params = translate_rank_range(params)
-    r = node_api_get('identifications', params=params, user_agent=user_agent)
+    r = node_api_get('identifications', params=params)
     r.raise_for_status()
 
     identifications = r.json()
@@ -237,7 +237,7 @@ def get_observation(observation_id: int, user_agent: str = None) -> JsonResponse
 
 
 @document_request_params([*docs._get_observations, docs._observation_histogram])
-def get_observation_histogram(user_agent: str = None, **params) -> HistogramResponse:
+def get_observation_histogram(**params) -> HistogramResponse:
     """Search observations and return histogram data for the given time interval
 
     **API reference:** https://api.inaturalist.org/v1/docs/#!/Observations/get_observations_histogram
@@ -286,13 +286,13 @@ def get_observation_histogram(user_agent: str = None, **params) -> HistogramResp
         Dict of ``{time_key: observation_count}``. Keys are ints for 'month of year' and\
         'week of year' intervals, and :py:class:`~datetime.datetime` objects for all other intervals.
     """
-    r = node_api_get('observations/histogram', params=params, user_agent=user_agent)
+    r = node_api_get('observations/histogram', params=params)
     r.raise_for_status()
     return format_histogram(r.json())
 
 
 @document_request_params([*docs._get_observations, docs._pagination, docs._only_id])
-def get_observations(user_agent: str = None, **params) -> JsonResponse:
+def get_observations(**params) -> JsonResponse:
     """Search observations.
 
     **API reference:** http://api.inaturalist.org/v1/docs/#!/Observations/get_observations
@@ -328,7 +328,7 @@ def get_observations(user_agent: str = None, **params) -> JsonResponse:
         Response dict containing observation records
     """
     validate_multiple_choice_param(params, 'order_by', NODE_OBS_ORDER_BY_PROPERTIES)
-    r = node_api_get('observations', params=params, user_agent=user_agent)
+    r = node_api_get('observations', params=params)
     r.raise_for_status()
 
     observations = r.json()
@@ -341,7 +341,7 @@ def get_observations(user_agent: str = None, **params) -> JsonResponse:
 # TODO: Consolidate logic from get_all_*() functions into a generic pagination function
 #       This would have two variations: by page number (most common) and by ID (as seen below)
 @document_request_params([*docs._get_observations, docs._only_id])
-def get_all_observations(user_agent: str = None, **params) -> List[JsonResponse]:
+def get_all_observations(**params) -> List[JsonResponse]:
     """Like :py:func:`get_observations()`, but handles pagination and returns all results in one
     call. Explicit pagination parameters will be ignored.
 
@@ -369,7 +369,6 @@ def get_all_observations(user_agent: str = None, **params) -> List[JsonResponse]
             'order_by': 'id',
             'order': 'asc',
             'per_page': PER_PAGE_RESULTS,
-            'user_agent': user_agent,
         },
     }
 
@@ -386,7 +385,7 @@ def get_all_observations(user_agent: str = None, **params) -> List[JsonResponse]
 
 
 @document_request_params([*docs._get_observations, docs._pagination])
-def get_observation_species_counts(user_agent: str = None, **params) -> JsonResponse:
+def get_observation_species_counts(**params) -> JsonResponse:
     """Get all species (or other 'leaf taxa') associated with observations matching the search
     criteria, and the count of observations they are associated with.
     **Leaf taxa** are the leaves of the taxonomic tree, e.g., species, subspecies, variety, etc.
@@ -407,14 +406,13 @@ def get_observation_species_counts(user_agent: str = None, **params) -> JsonResp
     r = node_api_get(
         'observations/species_counts',
         params=params,
-        user_agent=user_agent,
     )
     r.raise_for_status()
     return r.json()
 
 
 @document_request_params(docs._get_observations)
-def get_all_observation_species_counts(user_agent: str = None, **params) -> List[JsonResponse]:
+def get_all_observation_species_counts(**params) -> List[JsonResponse]:
     """Like :py:func:`get_observation_species_counts()`, but handles pagination and returns all
     results in one call. Explicit pagination parameters will be ignored.
 
@@ -424,7 +422,6 @@ def get_all_observation_species_counts(user_agent: str = None, **params) -> List
 
     Example:
         >>> get_all_observation_species_counts(
-        ...     user_agent=None,
         ...     quality_grade='research',
         ...     place_id=154695,
         ...     iconic_taxa='Reptilia',
@@ -446,7 +443,6 @@ def get_all_observation_species_counts(user_agent: str = None, **params) -> List
         **params,
         **{
             'per_page': PER_PAGE_RESULTS,
-            'user_agent': user_agent,
         },
     }
 
@@ -489,7 +485,7 @@ def get_geojson_observations(properties: List[str] = None, **params) -> JsonResp
 
 
 @document_request_params([*docs._get_observations, docs._pagination])
-def get_observation_observers(user_agent: str = None, **params) -> JsonResponse:
+def get_observation_observers(**params) -> JsonResponse:
     """Get observers of observations matching the search criteria and the count of
     observations and distinct taxa of rank species they have observed.
 
@@ -520,14 +516,13 @@ def get_observation_observers(user_agent: str = None, **params) -> JsonResponse:
     r = node_api_get(
         'observations/observers',
         params=params,
-        user_agent=user_agent,
     )
     r.raise_for_status()
     return r.json()
 
 
 @document_request_params([*docs._get_observations, docs._pagination])
-def get_observation_identifiers(user_agent: str = None, **params) -> JsonResponse:
+def get_observation_identifiers(**params) -> JsonResponse:
     """Get identifiers of observations matching the search criteria and the count of
     observations they have identified. By default, results are sorted by ID count in descending.
 
@@ -555,7 +550,6 @@ def get_observation_identifiers(user_agent: str = None, **params) -> JsonRespons
     r = node_api_get(
         'observations/identifiers',
         params=params,
-        user_agent=user_agent,
     )
     r.raise_for_status()
     return r.json()
@@ -600,7 +594,7 @@ def get_places_by_id(place_id: MultiInt, user_agent: str = None) -> JsonResponse
 
 
 @document_request_params([docs._bounding_box, docs._name])
-def get_places_nearby(user_agent: str = None, **params) -> JsonResponse:
+def get_places_nearby(**params) -> JsonResponse:
     """
     Given an bounding box, and an optional name query, return standard iNaturalist curator approved
     and community non-curated places nearby
@@ -651,7 +645,7 @@ def get_places_nearby(user_agent: str = None, **params) -> JsonResponse:
     Returns:
         Response dict containing place records, divided into 'standard' and 'community' places.
     """
-    r = node_api_get('places/nearby', params=params, user_agent=user_agent)
+    r = node_api_get('places/nearby', params=params)
     r.raise_for_status()
     return convert_all_place_coordinates(r.json())
 
@@ -696,7 +690,7 @@ def get_places_autocomplete(q: str, user_agent: str = None) -> JsonResponse:
 
 
 @document_request_params([docs._projects_params, docs._pagination])
-def get_projects(user_agent: str = None, **params) -> JsonResponse:
+def get_projects(**params) -> JsonResponse:
     """Given zero to many of following parameters, get projects matching the search criteria.
 
     **API reference:** https://api.inaturalist.org/v1/docs/#!/Projects/get_projects
@@ -733,7 +727,7 @@ def get_projects(user_agent: str = None, **params) -> JsonResponse:
         Response dict containing project records
     """
     validate_multiple_choice_param(params, 'order_by', PROJECT_ORDER_BY_PROPERTIES)
-    r = node_api_get('projects', params=params, user_agent=user_agent)
+    r = node_api_get('projects', params=params)
     r.raise_for_status()
 
     response = r.json()
@@ -785,7 +779,7 @@ def get_projects_by_id(
 
 
 @document_request_params([docs._taxon_params, docs._taxon_id_params])
-def get_taxa(user_agent: str = None, **params) -> JsonResponse:
+def get_taxa(**params) -> JsonResponse:
     """Given zero to many of following parameters, get taxa matching the search criteria.
 
     **API reference:** https://api.inaturalist.org/v1/docs/#!/Taxa/get_taxa
@@ -806,7 +800,7 @@ def get_taxa(user_agent: str = None, **params) -> JsonResponse:
         Response dict containing taxon records
     """
     params = translate_rank_range(params)
-    r = node_api_get('taxa', params=params, user_agent=user_agent)
+    r = node_api_get('taxa', params=params)
     r.raise_for_status()
 
     taxa = r.json()
@@ -851,7 +845,7 @@ def get_taxa_by_id(taxon_id: MultiInt, user_agent: str = None) -> JsonResponse:
 
 
 @document_request_params([docs._taxon_params, docs._minify])
-def get_taxa_autocomplete(user_agent: str = None, **params) -> JsonResponse:
+def get_taxa_autocomplete(**params) -> JsonResponse:
     """Given a query string, returns taxa with names starting with the search term
 
     **API reference:** https://api.inaturalist.org/v1/docs/#!/Taxa/get_taxa_autocomplete
@@ -882,7 +876,7 @@ def get_taxa_autocomplete(user_agent: str = None, **params) -> JsonResponse:
         Response dict containing taxon records
     """
     params = translate_rank_range(params)
-    r = node_api_get('taxa/autocomplete', params=params, user_agent=user_agent)
+    r = node_api_get('taxa/autocomplete', params=params)
     r.raise_for_status()
     json_response = r.json()
 

--- a/pyinaturalist/request_params.py
+++ b/pyinaturalist/request_params.py
@@ -1,4 +1,7 @@
-"""Helper functions for processing and validating request parameters"""
+"""Helper functions for processing and validating request parameters.
+The main purpose of these functions is to support some python-specific conveniences and translate
+them into standard request parameters, along with request validation that makes debugging easier.
+"""
 import warnings
 from datetime import date, datetime
 from dateutil.parser import parse as parse_timestamp
@@ -198,6 +201,7 @@ def preprocess_request_params(params: Optional[RequestParams]) -> RequestParams:
         return {}
 
     params = validate_multiple_choice_params(params)
+    params = convert_pagination_params(params)
     params = convert_bool_params(params)
     params = convert_datetime_params(params)
     params = convert_list_params(params)
@@ -256,6 +260,14 @@ def convert_observation_fields(params: RequestParams) -> RequestParams:
         params['observation_field_values_attributes'] = [
             {'observation_field_id': k, 'value': v} for k, v in obs_fields.items()
         ]
+    return params
+
+
+def convert_pagination_params(params: RequestParams) -> RequestParams:
+    """Allow ``count_only=True`` as a slightly more intuitive shortcut to only get a count of
+    results"""
+    if params.pop('count_only', None) is True:
+        params['per_page'] = 0
     return params
 
 

--- a/pyinaturalist/rest_api.py
+++ b/pyinaturalist/rest_api.py
@@ -44,7 +44,7 @@ from pyinaturalist.response_format import convert_all_coordinates, convert_all_t
         docs._pagination,
     ]
 )
-def get_observations(user_agent: str = None, **params) -> Union[List, str]:
+def get_observations(**params) -> Union[List, str]:
     """Get observation data, optionally in an alternative format. Also see
     :py:func:`.get_geojson_observations` for GeoJSON format (not included here because it wraps
     a separate API endpoint).
@@ -103,7 +103,6 @@ def get_observations(user_agent: str = None, **params) -> Union[List, str]:
     response = get(
         f'{API_V0_BASE_URL}/observations.{response_format}',
         params=params,
-        user_agent=user_agent,
     )
 
     if response_format == 'json':
@@ -116,7 +115,7 @@ def get_observations(user_agent: str = None, **params) -> Union[List, str]:
 
 
 @document_request_params([docs._search_query, docs._page])
-def get_observation_fields(user_agent: str = None, **params) -> ListResponse:
+def get_observation_fields(**params) -> ListResponse:
     """Search observation fields. Observation fields are basically typed data fields that
     users can attach to observation.
 
@@ -140,7 +139,6 @@ def get_observation_fields(user_agent: str = None, **params) -> ListResponse:
     response = get(
         f'{API_V0_BASE_URL}/observation_fields.json',
         params=params,
-        user_agent=user_agent,
     )
     response.raise_for_status()
 
@@ -243,9 +241,8 @@ def put_observation_field_values(
     return response.json()
 
 
-# TODO: more thorough usage example
 @document_request_params([docs._access_token, docs._create_observation])
-def create_observation(access_token: str = None, user_agent: str = None, **params) -> ListResponse:
+def create_observation(access_token: str = None, **params) -> ListResponse:
     """Create a new observation.
 
     **API reference:** https://www.inaturalist.org/pages/api+reference#post-observations
@@ -292,7 +289,6 @@ def create_observation(access_token: str = None, user_agent: str = None, **param
         url=f'{API_V0_BASE_URL}/observations.json',
         json={'observation': params},
         access_token=access_token,
-        user_agent=user_agent,
     )
     response.raise_for_status()
     return response.json()
@@ -309,7 +305,6 @@ def create_observation(access_token: str = None, user_agent: str = None, **param
 def update_observation(
     observation_id: int,
     access_token: str = None,
-    user_agent: str = None,
     **params,
 ) -> ListResponse:
     """
@@ -365,7 +360,6 @@ def update_observation(
         url=f'{API_V0_BASE_URL}/observations/{observation_id}.json',
         json={'observation': params},
         access_token=access_token,
-        user_agent=user_agent,
     )
     response.raise_for_status()
     return response.json()
@@ -438,8 +432,8 @@ def delete_observation(observation_id: int, access_token: str = None, user_agent
     response = delete(
         url=f'{API_V0_BASE_URL}/observations/{observation_id}.json',
         access_token=access_token,
-        user_agent=user_agent,
         headers={'Content-type': 'application/json'},
+        user_agent=user_agent,
     )
     if response.status_code == 404:
         raise ObservationNotFound

--- a/test/test_request_params.py
+++ b/test/test_request_params.py
@@ -10,6 +10,7 @@ from pyinaturalist.request_params import (
     convert_datetime_params,
     convert_list_params,
     convert_observation_fields,
+    convert_pagination_params,
     ensure_file_obj,
     get_interval_ranges,
     preprocess_request_params,
@@ -69,6 +70,19 @@ def test_convert_observation_fields():
     assert params['observation_field_values_attributes'] == [
         {'observation_field_id': 1, 'value': 'value'}
     ]
+
+
+def test_convert_pagination_params():
+    params = convert_pagination_params({'per_page': 100})
+    assert params['per_page'] == 100
+
+    params = convert_pagination_params({'per_page': 100, 'count_only': True})
+    assert params['per_page'] == 0
+    assert 'count_only' not in params
+
+    params = convert_pagination_params({'per_page': 100, 'count_only': False})
+    assert params['per_page'] == 100
+    assert 'count_only' not in params
 
 
 def test_ensure_file_obj__file_path():

--- a/test/test_request_params.py
+++ b/test/test_request_params.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from datetime import date, datetime
 from dateutil.tz import gettz
@@ -6,8 +5,6 @@ from io import BytesIO
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
-import pyinaturalist.node_api
-import pyinaturalist.rest_api
 from pyinaturalist.request_params import (
     convert_bool_params,
     convert_datetime_params,
@@ -21,7 +18,6 @@ from pyinaturalist.request_params import (
     validate_multiple_choice_param,
     validate_multiple_choice_params,
 )
-from test.conftest import MOCK_CREDS_ENV, get_mock_args_for_signature, get_module_http_functions
 
 TEST_PARAMS = {
     'is_active': False,
@@ -166,64 +162,6 @@ def test_validate_ids__invalid(value):
 def test_preprocess_request_params(mock_bool, mock_datetime, mock_list, mock_strip):
     preprocess_request_params({'id': 1})
     assert all([mock_bool.called, mock_datetime.called, mock_list.called, mock_strip.called])
-
-
-# The following tests ensure that all API requests call preprocess_request_params() at some point
-# Almost all logic except the request is mocked out so this can generically apply to all API functions
-# Using parametrization here so that on failure, pytest will show the specific function that failed
-@pytest.mark.parametrize(
-    'http_function', get_module_http_functions(pyinaturalist.node_api).values()
-)
-@patch('pyinaturalist.request_params.translate_rank_range')
-@patch('pyinaturalist.response_format.as_geojson_feature')
-@patch('pyinaturalist.node_api.format_histogram')
-@patch('pyinaturalist.node_api.convert_all_coordinates', side_effect=lambda x: x)
-@patch('pyinaturalist.node_api.convert_all_place_coordinates', side_effect=lambda x: x)
-@patch('pyinaturalist.api_requests.preprocess_request_params')
-@patch('pyinaturalist.api_requests.requests.Session.request')
-def test_all_node_requests_use_param_conversion(
-    request,
-    preprocess_request_params,
-    convert_all_place_coordinates,
-    convert_all_coordinates,
-    format_histogram,
-    as_geojson_feature,
-    translate_rank_range,
-    http_function,
-):
-    request().json.return_value = {'total_results': 1, 'results': [{'id': 1}]}
-    mock_args = get_mock_args_for_signature(http_function)
-    http_function(*mock_args)
-    assert preprocess_request_params.call_count == 1
-
-
-@pytest.mark.parametrize(
-    'http_function', get_module_http_functions(pyinaturalist.rest_api).values()
-)
-@patch.dict(os.environ, MOCK_CREDS_ENV)
-@patch('pyinaturalist.rest_api.convert_all_coordinates')
-@patch('pyinaturalist.rest_api.sleep')
-@patch('pyinaturalist.api_requests.preprocess_request_params')
-@patch('pyinaturalist.api_requests.requests.Session.request')
-def test_all_rest_requests_use_param_conversion(
-    request, preprocess_request_params, sleep, convert_all_place_coordinates, http_function
-):
-    # Handle the one API response that returns a list instead of a dict
-    if http_function in [
-        pyinaturalist.rest_api.get_observation_fields,
-        pyinaturalist.rest_api.get_all_observation_fields,
-    ]:
-        request().json.return_value = []
-    else:
-        request().json.return_value = {
-            'total_results': 1,
-            'access_token': '',
-            'results': [],
-        }
-
-    mock_args = get_mock_args_for_signature(http_function)
-    http_function(*mock_args)
-    assert preprocess_request_params.call_count == 1
 
 
 def test_validate_multiple_choice_param():


### PR DESCRIPTION
**Changes:**
* Add `count_only=True` as an alias for `per_page=0` (to get only result counts). This applies to all functions that support pagination:
  * `node_api.get_identifications()`                    
  * `node_api.get_observations()`                       
  * `node_api.get_observation_species_counts()`         
  * `node_api.get_observation_observers()`              
  * `node_api.get_observation_identifiers()`            
  * `node_api.get_projects()`                           
  * `rest_api.get_observations()`                       
  * `rest_api.get_observation_fields()`                 

* Remove explicit `user_agent` param from all functions decorated with `@document_request_params`, which will add it dynamically.
* Moved some logic from `request()` into a separate `prepare_request()` function, to make it easier to potentially use an alternative client (like `aiohttp`)

**Notes:**
* Explicit user_agent param is left on the remaining functions **not**
  decorated with `@document_request_params`, i.e. those with only a couple params
* Tests for each endpoint to call `preprocess_request_params()` are no
  longer necessary because all of them go through the functions in the `api_requests`
  module.
