### PR TITLE
Use POST /observation_photos to upload photos for create_observation() and update_observation()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
     * All can still be imported via `from pyinaturalist import *`
     * Imports from `pyinaturalist.rest_api` and `pyinaturalist.node_api` will still work, but are
       deprecated and will be removed in a future release
+* Update `create_observation()` and `update_observation()` to use `POST /observation_photos` endpoint to upload photos
 
 -----
 ## 0.13 (2021-05-22)

--- a/pyinaturalist/request_params.py
+++ b/pyinaturalist/request_params.py
@@ -316,11 +316,6 @@ def ensure_file_obj(photo: FileOrPath) -> BinaryIO:
     return photo
 
 
-def ensure_file_objs(photos: Iterable[FileOrPath]) -> Iterable[BinaryIO]:
-    """Given one or more file objects and/or paths, read any paths into a file-like object"""
-    return [ensure_file_obj(photo) for photo in ensure_list(photos)]
-
-
 def ensure_list(values: Any):
     """If the value is a string or comma-separated list of values, convert it into a list"""
     if not values:

--- a/pyinaturalist/v0/observation_fields.py
+++ b/pyinaturalist/v0/observation_fields.py
@@ -83,7 +83,7 @@ def put_observation_field_values(
         observation_id: ID of the observation receiving this observation field value
         observation_field_id: ID of the observation field for this observation field value
         value: Value for the observation field
-        access_token: access_token: The access token, as returned by :func:`get_access_token()`
+        access_token: The access token, as returned by :func:`get_access_token()`
         user_agent: A user-agent string that will be passed to iNaturalist.
 
     Returns:

--- a/scripts/observation_crud_test.py
+++ b/scripts/observation_crud_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# flake8: noqa: F401
 """A partially automated script for testing all observation CRUD endpoints,
 in absence of integration tests.
 iNat credentials must be provided via environment variables.
@@ -14,6 +15,7 @@ python scripts/obs_crud_test.py
 ```
 """
 from datetime import datetime
+from logging import basicConfig
 from os.path import join
 from pprint import pprint
 
@@ -23,13 +25,13 @@ from pyinaturalist import (
     delete_observation,
     get_access_token,
     get_observation,
+    put_observation_field_values,
     update_observation,
 )
 from pyinaturalist.constants import SAMPLE_DATA_DIR
 
-# put_observation_field_values,
-
 SAMPLE_PHOTO = join(SAMPLE_DATA_DIR, 'obs_image.jpg')
+basicConfig(level='INFO')
 
 
 def run_observation_crud_test():
@@ -46,7 +48,10 @@ def create_test_obs(token):
     response = create_observation(
         taxon_id=54327,
         observed_on_string=datetime.now().isoformat(),
-        description='This is a test observation used by pyinaturalist, and will be deleted shortly.',
+        description=(
+            'This is a test observation used for testing [pyinaturalist](https://github.com/niconoe/pyinaturalist), '
+            'and will be deleted shortly.'
+        ),
         tag_list='wasp, Belgium',
         latitude=50.647143,
         longitude=4.360216,
@@ -54,6 +59,7 @@ def create_test_obs(token):
         geoprivacy='open',
         access_token=token,
         observation_fields={297: 1},
+        local_photos=[SAMPLE_PHOTO, SAMPLE_PHOTO],
     )
     test_obs_id = response[0]['id']
     print(f'Created new observation: {test_obs_id}')
@@ -101,7 +107,6 @@ def delete_test_obs(test_obs_id, token):
     response = delete_observation(test_obs_id, token)
     # Empty response is expected
     print('Deleted observation')
-    pprint(response, indent=2)
 
 
 if __name__ == '__main__':

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,10 +5,11 @@ Pytest will also automatically pick up any fixtures defined here.
 import json
 import logging
 import os
+import pytest
 import re
 from inspect import Parameter, getmembers, isfunction, signature
 from os.path import join
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # If ipdb is installed, register it as the default debugger
 from pyinaturalist.constants import SAMPLE_DATA_DIR
@@ -39,6 +40,13 @@ MOCK_CREDS_OAUTH = {
 # Enable logging for urllib and other external loggers
 logging.basicConfig(level='INFO')
 logging.getLogger('pyinaturalist').setLevel('DEBUG')
+
+
+@pytest.fixture(scope='function', autouse=True)
+def patch_ratelimit():
+    """Disable rate-limiting during test session"""
+    with patch('pyinaturalist.api_requests.ratelimit'):
+        yield
 
 
 def get_module_functions(module):


### PR DESCRIPTION
Fixes issue #150 

Noticed this note in the [API docs](https://www.inaturalist.org/pages/api+reference#post-observations):
> **local_photos[]**
    List of fields containing uploaded photo data. Request must have a Content-Type of "multipart." We recommend that you use the POST /observation_photos endpoint instead. 