### PR TITLE
Fix upload_sounds, and other improvements for POST and PUT endpoints

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 
 ### New Endpoints
 * Added new function for **Observation sounds** endpoint: `upload_sounds()`
+
 ### Modified Endpoints
 * Added a `photos` parameter `create_observation()` and `update_observation()` to upload photos
 * Added a `sounds` parameter `create_observation()` and `update_observation()` to upload sounds
@@ -12,7 +13,8 @@
   * The alias `rest_api.add_photo_to_observation()` is still available for backwards-compatibility
 * Updated `upload_photos()` to take accept either a single photo or a list of photos, and return a list of responses
 * Updated `upload_sounds()` to take accept either a single sound or a list of sounds, and return a list of responses
-* Updated upload_photos()
+* Added alias `observed_on` for `observed_on_string` in `create_observation()`
+* Updated all requests to correctly convert `datetime` objects to strings
 * Moved API functions into separate modules by API version and resource type.
     * All can still be imported via `from pyinaturalist import *`
     * Added aliases for backwards-compatibility, so imports from `pyinaturalist.rest_api` and

--- a/pyinaturalist/api_docs.py
+++ b/pyinaturalist/api_docs.py
@@ -3,13 +3,13 @@ Reusable template functions used for API documentation.
 Each template function contains a portion of an endpoint's request parameters, with corresponding
 type annotations and docstrings.
 """
-from typing import Iterable, List
+from typing import List
 
 from pyinaturalist.constants import (
-    Date,
-    DateTime,
-    FileOrPath,
+    AnyDate,
+    AnyDateTime,
     IntOrStr,
+    MultiFile,
     MultiInt,
     MultiIntOrStr,
     MultiStr,
@@ -46,12 +46,12 @@ def _identification_params(
     observation_hrank: str = None,
     without_taxon_id: MultiInt = None,
     without_observation_taxon_id: MultiInt = None,
-    d1: Date = None,
-    d2: Date = None,
-    observation_created_d1: Date = None,
-    observation_created_d2: Date = None,
-    observed_d1: Date = None,
-    observed_d2: Date = None,
+    d1: AnyDate = None,
+    d2: AnyDate = None,
+    observation_created_d1: AnyDate = None,
+    observation_created_d2: AnyDate = None,
+    observed_d1: AnyDate = None,
+    observed_d2: AnyDate = None,
     id_above: int = None,
     id_below: int = None,
 ):
@@ -98,8 +98,8 @@ def _identification_params(
 # Params that are in most observation-related endpoints in both Node and REST APIs
 def _observation_common(
     q: str = None,
-    d1: Date = None,
-    d2: Date = None,
+    d1: AnyDate = None,
+    d2: AnyDate = None,
     day: MultiInt = None,
     month: MultiInt = None,
     year: MultiInt = None,
@@ -112,7 +112,7 @@ def _observation_common(
     taxon_id: MultiInt = None,
     taxon_name: MultiStr = None,
     iconic_taxa: MultiStr = None,
-    updated_since: DateTime = None,
+    updated_since: AnyDateTime = None,
 ):
     """
     q: Search observation properties
@@ -168,10 +168,10 @@ def _observation_node_only(
     without_term_value_id: MultiInt = None,
     acc_above: str = None,
     acc_below: str = None,
-    created_d1: DateTime = None,
-    created_d2: DateTime = None,
-    created_on: Date = None,
-    observed_on: Date = None,
+    created_d1: AnyDateTime = None,
+    created_d2: AnyDateTime = None,
+    created_on: AnyDate = None,
+    observed_on: AnyDate = None,
     unobserved_by_user_id: int = None,
     apply_project_rules_for: str = None,
     cs: str = None,
@@ -277,11 +277,11 @@ def _observation_node_only(
 # Observation params that are only in the REST API
 def _observation_rest_only(
     has: MultiStr = None,
-    on: Date = None,
-    m1: Date = None,
-    m2: Date = None,
-    h1: Date = None,
-    h2: Date = None,
+    on: AnyDate = None,
+    m1: AnyDate = None,
+    m2: AnyDate = None,
+    h1: AnyDate = None,
+    h2: AnyDate = None,
     extra: str = None,
     response_format: str = 'json',
 ):
@@ -315,7 +315,8 @@ def _observation_histogram(
 def _create_observation(
     species_guess: str = None,
     taxon_id: int = None,
-    observed_on_string: Date = None,
+    observed_on: AnyDate = None,
+    observed_on_string: AnyDate = None,
     time_zone: str = None,
     description: str = None,
     tag_list: MultiStr = None,
@@ -330,14 +331,15 @@ def _create_observation(
     flickr_photos: MultiInt = None,
     picasa_photos: MultiStr = None,
     facebook_photos: MultiStr = None,
-    local_photos: Iterable[FileOrPath] = None,
-    photos: Iterable[FileOrPath] = None,
-    sounds: Iterable[FileOrPath] = None,
+    local_photos: MultiFile = None,
+    photos: MultiFile = None,
+    sounds: MultiFile = None,
 ):
     """
     species_guess: Equivalent to the 'What did you see?' field on the observation form.
         iNat will try to choose a single taxon based on this, but it may fail if it's ambuguous
     taxon_id: ID of the taxon to associate with this observation
+    observed_on: Alias for ``observed_on_string``; accepts :py:class:`~datetime.datetime` objects.
     observed_on_string: Date/time of the observation. Time zone will default to the user's
         time zone if not specified.
     time_zone: Time zone the observation was made in

--- a/pyinaturalist/api_requests.py
+++ b/pyinaturalist/api_requests.py
@@ -39,6 +39,7 @@ def request(
     ids: MultiInt = None,
     params: RequestParams = None,
     headers: Dict = None,
+    json: Dict = None,
     session: requests.Session = None,
     **kwargs,
 ) -> requests.Response:
@@ -53,12 +54,22 @@ def request(
         ids: One or more integer IDs used as REST resource(s) to request
         params: Requests parameters
         headers: Request headers
+        json: JSON request body
         session: Existing Session object to use instead of creating a new one
+        kwargs: Additional keyword arguments for :py:meth:`requests.Session.request`
 
     Returns:
         API response
     """
-    url, params, headers = prepare_request(url, access_token, user_agent, ids, params, headers)
+    url, params, headers, json = prepare_request(
+        url,
+        access_token,
+        user_agent,
+        ids,
+        params,
+        headers,
+        json,
+    )
     session = session or get_session()
 
     # Run either real request or mock request depending on settings
@@ -68,7 +79,7 @@ def request(
         return MOCK_RESPONSE
     else:
         with ratelimit():
-            return session.request(method, url, params=params, headers=headers, **kwargs)
+            return session.request(method, url, params=params, headers=headers, json=json, **kwargs)
 
 
 @copy_signature(request, exclude='method')

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -36,8 +36,8 @@ SAMPLE_DATA_DIR = join(PROJECT_DIR, 'test', 'sample_data')
 
 # Type aliases
 Coordinates = Tuple[float, float]
-Date = Union[date, datetime, str]
-DateTime = Union[datetime, str]
+AnyDate = Union[date, datetime, str]
+AnyDateTime = Union[datetime, str]
 DateOrInt = Union[date, datetime, int]
 Dimensions = Tuple[int, int]
 FileOrPath = Union[BinaryIO, str]
@@ -49,7 +49,8 @@ ObsFieldValues = Union[Dict, List[Dict]]
 RequestParams = Dict[str, Any]
 ResponseObject = Dict[str, Any]
 ResponseOrObject = Union[JsonResponse, ResponseObject, Iterable[ResponseObject]]
-MultiInt = Union[int, List[int]]
-MultiStr = Union[str, List[str]]
+MultiFile = Union[FileOrPath, Iterable[FileOrPath]]
+MultiInt = Union[int, Iterable[int]]
+MultiStr = Union[str, Iterable[str]]
 MultiIntOrStr = Union[MultiInt, MultiStr]
 TemplateFunction = Any  # Cannot use Callable/Protocol, as these will not allow a mix of signatures

--- a/pyinaturalist/v0/observations.py
+++ b/pyinaturalist/v0/observations.py
@@ -336,7 +336,7 @@ def upload_sounds(
         response = post(
             url=f'{API_V0_BASE_URL}/observation_sounds',
             access_token=access_token,
-            data={'observation_sounds[observation_id]': observation_id},
+            params={'observation_sound[observation_id]': observation_id},
             files={'file': ensure_file_obj(sound)},
             user_agent=user_agent,
         )

--- a/pyinaturalist/v0/observations.py
+++ b/pyinaturalist/v0/observations.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 from pyinaturalist import api_docs as docs
 from pyinaturalist.api_requests import delete, get, post, put
-from pyinaturalist.constants import API_V0_BASE_URL, FileOrPath, ListResponse
+from pyinaturalist.constants import API_V0_BASE_URL, ListResponse, MultiFile
 from pyinaturalist.exceptions import ObservationNotFound
 from pyinaturalist.forge_utils import document_request_params
 from pyinaturalist.pagination import add_paginate_all
@@ -141,6 +141,8 @@ def create_observation(access_token: str, **params) -> ListResponse:
     if 'observation' in params:
         params.update(params.pop('observation'))
     params = convert_observation_fields(params)
+    if 'observed_on' in params:
+        params['observed_on_string'] = params.pop('observed_on')
 
     # Split out photos and sounds to upload separately
     photos = ensure_list(params.pop('local_photos', None))
@@ -243,7 +245,7 @@ def update_observation(
 
 def upload_photos(
     observation_id: int,
-    photos: FileOrPath,
+    photos: MultiFile,
     access_token: str,
     user_agent: str = None,
 ) -> ListResponse:
@@ -283,18 +285,21 @@ def upload_photos(
         response = post(
             url=f'{API_V0_BASE_URL}/observation_photos',
             access_token=access_token,
-            data={'observation_photo[observation_id]': observation_id},
+            params={'observation_photo[observation_id]': observation_id},
             files={'file': ensure_file_obj(photo)},
             user_agent=user_agent,
         )
         responses.append(response)
 
+    # Wait until all uploads complete to raise errors for any failed uploads
+    for response in responses:
+        response.raise_for_status()
     return [response.json() for response in responses]
 
 
 def upload_sounds(
     observation_id: int,
-    sounds: FileOrPath,
+    sounds: MultiFile,
     access_token: str,
     user_agent: str = None,
 ) -> ListResponse:
@@ -342,6 +347,9 @@ def upload_sounds(
         )
         responses.append(response)
 
+    # Wait until all uploads complete to raise errors for any failed uploads
+    for response in responses:
+        response.raise_for_status()
     return [response.json() for response in responses]
 
 
@@ -367,7 +375,6 @@ def delete_observation(observation_id: int, access_token: str = None, user_agent
     response = delete(
         url=f'{API_V0_BASE_URL}/observations/{observation_id}.json',
         access_token=access_token,
-        headers={'Content-type': 'application/json'},
         user_agent=user_agent,
     )
     if response.status_code == 404:

--- a/scripts/observation_crud_test.py
+++ b/scripts/observation_crud_test.py
@@ -47,7 +47,7 @@ def run_observation_crud_test():
 def create_test_obs(token):
     response = create_observation(
         taxon_id=54327,
-        observed_on_string=datetime.now().isoformat(),
+        observed_on=datetime.now(),
         description=(
             'This is a test observation used for testing [pyinaturalist](https://github.com/niconoe/pyinaturalist), '
             'and will be deleted shortly.'
@@ -59,7 +59,7 @@ def create_test_obs(token):
         geoprivacy='open',
         access_token=token,
         observation_fields={297: 1},
-        local_photos=[SAMPLE_PHOTO, SAMPLE_PHOTO],
+        photos=[SAMPLE_PHOTO, SAMPLE_PHOTO],
     )
     test_obs_id = response[0]['id']
     print(f'Created new observation: {test_obs_id}')

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -21,6 +21,7 @@ def test_http_methods(mock_request, http_func, http_method):
         'https://url',
         params={'key': 'value'},
         headers={'Accept': 'application/json', 'User-Agent': pyinaturalist.user_agent},
+        json=None,
     )
 
 


### PR DESCRIPTION
Updates #153 

* Fix `upload_photos()` by sending observation_id in request params instead of request body
* Add alias `observed_on` for `observed_on_string` in `create_observation()`
* Update all requests to convert any `date` or `datetime` values to strings in request body