### PR TITLE
api_requests module refactoring

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 # History
 
 ## 0.15.0 (2021-TBD)
+* Improved logging output for dry-run mode: now shows formatted `PreparedRequest` details
+  instead of `request()` keyword args
+* Added an `enable_logging()` function to optionally show prettier logs with `rich`
 * Allow all API request functions to accept a `limiter` argument to override rate-limiting settings
 * Allow all API request functions to accept a `dry_run` argument to dry-run an individual request
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -348,24 +348,41 @@ For example, to increase the rate to 75 requests per minute:
 >>> get_taxa(q='warbler', locale=1, limiter=limiter)
 ```
 
+## Logging
+You can configure logging for pyinaturalist using the standard Python `logging` module, for example
+with {py:func}`logging.basicConfig`:
+```python
+import logging
+logging.basicConfig()
+logging.getLogger('pyinaturalist').setLevel('INFO')
+```
+
+For convenience, an {py:func}`.enable_logging` function is included that will apply some recommended
+settings, including colorized output (if viewed in a terminal) and better traceback formatting,
+using the [rich](https://rich.readthedocs.io) library.
+```python
+>>> from pyinaturalist import enable_logging
+>>> enable_logging()
+```
+
 ## Dry-run mode
 While developing and testing, it can be useful to temporarily mock out HTTP requests, especially
 requests that add, modify, or delete real data. Pyinaturalist has some settings to make this easier.
 
 ### Dry-run individual requests
 All API request functions take an optional `dry_run` argument. When set to `True`, requests will not
-be sent but will be logged instead:
+be sent but will be logged instead.
+
+```{note}
+You must enable at least INFO-level logging to see the logged request info
+```
 ```python
->>> import logging
 >>> from pyinaturalist import get_taxa
->>> # Enable at least INFO-level logging to see the request info
->>> logging.basicConfig(level='INFO')
->>>
 >>> get_taxa(q='warbler', locale=1, dry_run=True)
 {'results': [], 'total_results': 0}
-INFO:pyinaturalist.api_requests:Request: GET, https://api.inaturalist.org/v1/taxa,
-    params={'q': 'warbler', 'locale': 1},
-    headers={'Accept': 'application/json', 'User-Agent': 'Pyinaturalist/0.9.1'}
+[07-26 18:55:50] INFO  Request: GET https://api.inaturalist.org/v1/taxa?q=warbler&locale=1
+User-Agent: pyinaturalist/0.15.0                                                 
+Accept: application/json                                                         
 ```
 
 ### Dry-run all requests

--- a/pyinaturalist/__init__.py
+++ b/pyinaturalist/__init__.py
@@ -7,7 +7,7 @@ user_agent = DEFAULT_USER_AGENT
 try:
     from pyinaturalist.auth import get_access_token
     from pyinaturalist.constants import *
-    from pyinaturalist.formatters import format_table, pprint
+    from pyinaturalist.formatters import enable_logging, format_table, pprint
     from pyinaturalist.models import *
     from pyinaturalist.v0 import *
     from pyinaturalist.v1 import *

--- a/pyinaturalist/api_requests.py
+++ b/pyinaturalist/api_requests.py
@@ -1,14 +1,14 @@
 """Some common functions for HTTP requests used by all API modules"""
 # TODO: Default retry and backoff settings
 import threading
-from contextlib import contextmanager
 from logging import getLogger
 from os import getenv
 from typing import Dict
 from unittest.mock import Mock
+from warnings import warn
 
 from pyrate_limiter import Duration, Limiter, RequestRate
-from requests import Response, Session
+from requests import PreparedRequest, Request, Response, Session
 
 import pyinaturalist
 from pyinaturalist.constants import (
@@ -21,7 +21,11 @@ from pyinaturalist.constants import (
     RequestParams,
 )
 from pyinaturalist.docs import copy_signature
-from pyinaturalist.request_params import prepare_request
+from pyinaturalist.request_params import (
+    convert_url_ids,
+    preprocess_request_body,
+    preprocess_request_params,
+)
 
 # Default rate-limiting settings
 RATE_LIMITER = Limiter(
@@ -73,7 +77,8 @@ def request(
     Returns:
         API response
     """
-    url, params, headers, json = prepare_request(
+    request = prepare_request(
+        method,
         url,
         access_token,
         user_agent,
@@ -82,22 +87,54 @@ def request(
         headers,
         json,
     )
+    bucket = request.headers.get('User-Agent') or 'pyinaturalist'
     limiter = limiter or RATE_LIMITER
     session = session or get_session()
 
-    # Run either real request or mock request depending on settings
+    # Make a mock request, if specified
     if dry_run or is_dry_run_enabled(method):
         logger.debug('Dry-run mode enabled; mocking request')
         log_request(method, url, params=params, headers=headers)
         return MOCK_RESPONSE
+    # Otherwise, apply rate-limiting and send the request
     else:
-        with ratelimit():
-            response = session.request(
-                method, url, params=params, headers=headers, json=json, timeout=timeout
-            )
+        with limiter.ratelimit(bucket=bucket, delay=True, max_delay=MAX_DELAY):
+            response = session.send(request, timeout=timeout)
         if raise_for_status:
             response.raise_for_status()
         return response
+
+
+def prepare_request(
+    method: str,
+    url: str,
+    access_token: str = None,
+    user_agent: str = None,
+    ids: MultiInt = None,
+    params: RequestParams = None,
+    headers: Dict = None,
+    json: Dict = None,
+    **kwargs,
+) -> PreparedRequest:
+    """Translate ``pyinaturalist``-specific options into standard request arguments."""
+    # Prepare request params and URL
+    params = preprocess_request_params(params)
+    url = convert_url_ids(url, ids)
+
+    # Prepare user-agent and authentication headers
+    headers = headers or {}
+    headers['User-Agent'] = user_agent or pyinaturalist.user_agent
+    headers['Accept'] = 'application/json'
+    if access_token:
+        headers['Authorization'] = f'Bearer {access_token}'
+
+    # Convert any datetimes to strings in request body
+    if json:
+        headers['Content-type'] = 'application/json'
+        json = preprocess_request_body(json)
+
+    request = Request(method=method, url=url, headers=headers, json=json, params=params, **kwargs)
+    return request.prepare()
 
 
 @copy_signature(request, exclude='method')
@@ -122,19 +159,6 @@ def post(url: str, **kwargs) -> Response:
 def put(url: str, **kwargs) -> Response:
     """Wrapper around :py:func:`requests.put` with additional options specific to iNat API requests"""
     return request('PUT', url, **kwargs)
-
-
-# TODO: Handle error 429 if we still somehow exceed the rate limit?
-@contextmanager
-def ratelimit(bucket=pyinaturalist.user_agent):
-    """Add delays in between requests to stay within the rate limits. If pyrate-limiter is
-    not installed, this will quietly do nothing.
-    """
-    if RATE_LIMITER:
-        with RATE_LIMITER.ratelimit(bucket, delay=True, max_delay=MAX_DELAY):
-            yield
-    else:
-        yield
 
 
 def get_session() -> Session:
@@ -167,6 +191,7 @@ def env_to_bool(environment_variable: str) -> bool:
     return bool(env_value) and str(env_value).lower() not in ['false', 'none']
 
 
+# TODO: Prettier formatting + terminal colors with `rich`
 def log_request(*args, **kwargs):
     """Log all relevant information about an HTTP request"""
     kwargs_strs = [f'{k}={v}' for k, v in kwargs.items()]

--- a/pyinaturalist/api_requests.py
+++ b/pyinaturalist/api_requests.py
@@ -21,6 +21,7 @@ from pyinaturalist.constants import (
     RequestParams,
 )
 from pyinaturalist.docs import copy_signature
+from pyinaturalist.formatters import format_request
 from pyinaturalist.request_params import (
     convert_url_ids,
     preprocess_request_body,
@@ -38,7 +39,7 @@ RATE_LIMITER = Limiter(
 MOCK_RESPONSE = Mock(spec=Response)
 MOCK_RESPONSE.json.return_value = {'results': [], 'total_results': 0, 'access_token': ''}
 
-logger = getLogger(__name__)
+logger = getLogger('pyinaturalist')
 thread_local = threading.local()
 
 
@@ -93,8 +94,7 @@ def request(
 
     # Make a mock request, if specified
     if dry_run or is_dry_run_enabled(method):
-        logger.debug('Dry-run mode enabled; mocking request')
-        log_request(method, url, params=params, headers=headers)
+        logger.info(format_request(request))
         return MOCK_RESPONSE
     # Otherwise, apply rate-limiting and send the request
     else:
@@ -172,11 +172,19 @@ def get_session() -> Session:
     return thread_local.session
 
 
+# TODO: Drop support for global variables in version 0.16
 def is_dry_run_enabled(method: str) -> bool:
     """A wrapper to determine if dry-run (aka test mode) has been enabled via either
     a constant or an environment variable. Dry-run mode may be enabled for either write
     requests, or all requests.
     """
+    if pyinaturalist.DRY_RUN_ENABLED or pyinaturalist.DRY_RUN_WRITE_ONLY:
+        msg = (
+            'Global varibale usage is deprecated; please use environment variables or dry_run '
+            'keyword argument instead'
+        )
+        warn(DeprecationWarning(msg))
+
     dry_run_enabled = pyinaturalist.DRY_RUN_ENABLED or env_to_bool('DRY_RUN_ENABLED')
     if method in WRITE_HTTP_METHODS:
         return dry_run_enabled or pyinaturalist.DRY_RUN_WRITE_ONLY or env_to_bool('DRY_RUN_WRITE_ONLY')
@@ -189,10 +197,3 @@ def env_to_bool(environment_variable: str) -> bool:
     """
     env_value = getenv(environment_variable)
     return bool(env_value) and str(env_value).lower() not in ['false', 'none']
-
-
-# TODO: Prettier formatting + terminal colors with `rich`
-def log_request(*args, **kwargs):
-    """Log all relevant information about an HTTP request"""
-    kwargs_strs = [f'{k}={v}' for k, v in kwargs.items()]
-    logger.info('Request: {}'.format(', '.join(list(args) + kwargs_strs)))

--- a/pyinaturalist/formatters.py
+++ b/pyinaturalist/formatters.py
@@ -10,6 +10,7 @@ These functions will accept any of the following:
 from copy import deepcopy
 from datetime import date, datetime
 from functools import partial
+from logging import basicConfig, getLogger
 from typing import List, Type
 
 from requests import PreparedRequest
@@ -47,6 +48,24 @@ try:
     pretty.install()
 except ImportError:
     pass
+
+
+def enable_logging(level: str = 'INFO'):
+    """Configure logging to standard output with prettier tracebacks and terminal colors (if supported).
+    Logging can of course be configured however you want using the stdlib ``logging`` module; this is
+    just here for convenience.
+
+    Args:
+        level: Logging level to use
+    """
+    from rich.logging import RichHandler
+
+    basicConfig(
+        format='%(message)s',
+        datefmt='[%m-%d %H:%M:%S]',
+        handlers=[RichHandler(rich_tracebacks=True, markup=True)],
+    )
+    getLogger('pyinaturalist').setLevel(level)
 
 
 # Default colors for table headers

--- a/pyinaturalist/formatters.py
+++ b/pyinaturalist/formatters.py
@@ -12,6 +12,8 @@ from datetime import date, datetime
 from functools import partial
 from typing import List, Type
 
+from requests import PreparedRequest
+
 from pyinaturalist.constants import ResponseOrResults, ResponseResult
 from pyinaturalist.converters import ensure_list
 from pyinaturalist.models import (
@@ -161,6 +163,17 @@ def format_table(values: ResponseOrObjects):
     for obj in values:
         table.add_row(*[_str(value) for value in obj.row.values()])
     return table
+
+
+def format_request(request: PreparedRequest) -> str:
+    """Format HTTP request info"""
+    headers_dict = request.headers
+    if 'Authorization' in headers_dict:
+        headers_dict['Authorization'] = '[REDACTED]'
+
+    headers = '\n'.join([f'{k}: {v}' for k, v in headers_dict.items()])
+    body = '\n\n{request.body}' if request.body else ''
+    return f'Request: {request.method} {request.url}\n{headers}{body}'
 
 
 # TODO: This maybe belongs in a different module

--- a/pyinaturalist/models/observation.py
+++ b/pyinaturalist/models/observation.py
@@ -33,7 +33,6 @@ from pyinaturalist.models import (
     field,
     upper,
 )
-from pyinaturalist.v1 import get_observation
 
 
 @define(auto_attribs=False, init=False, field_transformer=add_lazy_attrs)
@@ -201,6 +200,8 @@ class Observation(BaseModel):
     @classmethod
     def from_id(cls, id: int):
         """Lookup and create a new Observation object from an ID"""
+        from pyinaturalist.v1 import get_observation
+
         json = get_observation(id)
         return cls.from_json(json)
 

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -27,7 +27,6 @@ from pyinaturalist.models import (
     field,
     upper,
 )
-from pyinaturalist.v1 import get_taxa_by_id
 
 
 # TODO: Some more properties to consolidate differences between endpoints? (place_id vs. place, etc.)
@@ -241,6 +240,8 @@ class Taxon(BaseModel):
     @classmethod
     def from_id(cls, id: int) -> 'Taxon':
         """Lookup and create a new Taxon object by ID"""
+        from pyinaturalist.v1 import get_taxa_by_id
+
         r = get_taxa_by_id(id)
         return cls.from_json(r['results'][0])  # type: ignore
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,7 +45,7 @@ logging.getLogger('pyinaturalist').setLevel('DEBUG')
 @pytest.fixture(scope='function', autouse=True)
 def patch_ratelimit():
     """Disable rate-limiting during test session"""
-    with patch('pyinaturalist.api_requests.ratelimit'):
+    with patch('pyinaturalist.api_requests.RATE_LIMITER'):
         yield
 
 

--- a/test/v0/test_observations_v0.py
+++ b/test/v0/test_observations_v0.py
@@ -72,7 +72,7 @@ def test_create_observation(requests_mock):
 @patch('pyinaturalist.v0.observations.post')
 def test_create_observation__with_datetime(post, requests_mock):
     """Just test that request param aliases work. Datetimes are converted to strings separately in
-    request_params.prepare_request().
+    prepare_request().
     """
     requests_mock.post(
         f'{API_V0_BASE_URL}/observations.json',

--- a/test/v1/test_taxa.py
+++ b/test/v1/test_taxa.py
@@ -54,14 +54,6 @@ def test_get_taxa_by_rank_range(
     assert requested_rank == expected_ranks
 
 
-# This is just a spot test of a case in which boolean params should be converted
-@patch('pyinaturalist.api_requests.Session.request')
-def test_get_taxa_by_name_and_is_active(request):
-    get_taxa(q='Lixus bardanae', is_active=False)
-    params = request.call_args[1]['params']
-    assert params['q'] == 'Lixus bardanae' and params['is_active'] == 'false'
-
-
 def test_get_taxa_by_id(requests_mock):
     taxon_id = 70118
     requests_mock.get(


### PR DESCRIPTION
This is partly to support #163. Also closes #213.

* Refactor api_requests module to use PreparedRequests
* Improve request formatting in dry-run mode
* Add an `enable_logging()` function to add formatted tracebacks and terminal colors with rich