### PR TITLE
Refactor rate-limiting to not apply limits to cached requests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,9 +22,9 @@
   * UserCounts
 
 ### Modified Endpoints
-* Add a `limiter` argument to all API request functions to override rate-limiting settings
 * Add a `dry_run` argument to all API request functions to dry-run an individual request
 * Add a `reverse` argument to all paginated API request functions to reverse the sort order
+
 ### Logging
 * Improved logging output for dry-run mode: now shows formatted `PreparedRequest` details
   instead of `request()` keyword args
@@ -34,6 +34,7 @@
 ### Other Changes
 * Add API request caching with [requests-cache](https://github.com/reclosedev/requests-cache)
   (can be disabled or customized via `session` parameter)
+* Make rate-limiting not apply to cached requests
 * Fix bug with `rule_details` param for `get_projects_by_id()`
 
 ## 0.14.1 (2021-07-21)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'requests': ('https://requests.readthedocs.io/en/master/', None),
     'requests_cache': ('https://requests-cache.readthedocs.io/en/stable/', None),
+    'requests_ratelimiter': ('https://requests-ratelimiter.readthedocs.io/en/latest/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/stable/', None),
 }
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -334,28 +334,27 @@ Credentials storage with keyring + KeePassXC
 ```
 
 ## Rate Limiting
-By default, pyinaturalist applies rate limiting to all requests so they stay within the rates specified by
-iNaturalist's [API Recommended Practices](https://www.inaturalist.org/pages/api+recommended+practices).
-If you want to customize these rate limits, all API request functions take an optional `limiter` argument,
-which takes a [`pyrate_limiter.Limiter`](https://github.com/vutran1710/PyrateLimiter) object.
+Rate limiting is applied to all requests so they stay within the rates specified by iNaturalist's
+[API Recommended Practices](https://www.inaturalist.org/pages/api+recommended+practices).
 
-For example, to reduce the rate to 50 requests per minute:
+If you want to customize these rate limits, you can make a
+[Session](https://docs.python-requests.org/en/latest/user/advanced/#session-objects) to use for API
+requests. The easiest way to do this is with {py:func}`.get_session`. For example, to reduce the
+rate to 50 requests per minute:
+
 ```python
->>> from pyinaturalist import get_limiter, get_taxa
->>> from pyrate_limiter import Duration, Limiter, RequestRate
->>>
->>> limiter = get_limiter(per_minute=50)
->>> get_taxa(q='warbler', locale=1, limiter=limiter)
+>>> from pyinaturalist import get_session, get_taxa
+>>> session = get_session(per_minute=50)
+>>> get_taxa(q='warbler', locale=1, session=session)
 ```
 
 ## Logging
 You can configure logging for pyinaturalist using the standard Python `logging` module, for example
 with {py:func}`logging.basicConfig`:
 ```python
-import logging
-
-logging.basicConfig()
-logging.getLogger('pyinaturalist').setLevel('INFO')
+>>> import logging
+>>> logging.basicConfig()
+>>> logging.getLogger('pyinaturalist').setLevel('INFO')
 ```
 
 For convenience, an {py:func}`.enable_logging` function is included that will apply some recommended

--- a/poetry.lock
+++ b/poetry.lock
@@ -487,13 +487,14 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 
 [[package]]
 name = "jupyter-client"
-version = "6.1.13"
+version = "7.0.2"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.6.1"
 
 [package.dependencies]
+entrypoints = "*"
 jupyter-core = ">=4.6.0"
 nest-asyncio = ">=1.5"
 python-dateutil = ">=2.1"
@@ -502,8 +503,8 @@ tornado = ">=4.1"
 traitlets = "*"
 
 [package.extras]
-doc = ["sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-test = ["async-generator", "ipykernel", "ipython", "mock", "pytest-asyncio", "pytest-timeout", "pytest", "mypy", "pre-commit", "jedi (<0.18)"]
+doc = ["myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
+test = ["codecov", "coverage", "ipykernel", "ipython", "mock", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "jedi (<0.18)"]
 
 [[package]]
 name = "jupyter-core"
@@ -688,14 +689,14 @@ testing = ["beautifulsoup4", "coverage", "docutils (>=0.17.0,<0.18.0)", "pytest 
 
 [[package]]
 name = "nbclient"
-version = "0.5.1"
+version = "0.5.4"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.6.1"
 
 [package.dependencies]
-async-generator = "*"
+async-generator = {version = "*", markers = "python_version < \"3.7\""}
 jupyter-client = ">=6.1.5"
 nbformat = ">=5.0"
 nest-asyncio = "*"
@@ -1612,8 +1613,8 @@ docs = ["furo", "ipython", "linkify-it-py", "myst-parser", "nbsphinx", "sphinx",
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "f3d8978e922a064bd223dd857fe84105c79ddbbf3abb51bf7480bb77f984ad8b"
+python-versions = "^3.6.2"
+content-hash = "303ce9cee3448db758a02d902a811b8e8ef79bbc244f148c2a82842ae2bb5f97"
 
 [metadata.files]
 alabaster = [
@@ -1893,8 +1894,8 @@ jsonschema = [
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-6.1.13-py3-none-any.whl", hash = "sha256:1df17b0525b45cc03645fc9eeab023765882d3c18fb100f82499cf6a353b3941"},
-    {file = "jupyter_client-6.1.13.tar.gz", hash = "sha256:d03558bc9b7955d8b4a6df604a8d9d257e00bcea7fb364fe41cdef81d998a966"},
+    {file = "jupyter_client-7.0.2-py3-none-any.whl", hash = "sha256:37a30c13d3655b819add61c830594090af7fca40cd2d74f41cad9e2e12118501"},
+    {file = "jupyter_client-7.0.2.tar.gz", hash = "sha256:0c6cabd07e003a2e9692394bf1ae794188ad17d2e250ed747232d7a473aa772c"},
 ]
 jupyter-core = [
     {file = "jupyter_core-4.7.1-py3-none-any.whl", hash = "sha256:8c6c0cac5c1b563622ad49321d5ec47017bd18b94facb381c6973a0486395f8e"},
@@ -2001,8 +2002,8 @@ myst-parser = [
     {file = "myst_parser-0.15.2-py3-none-any.whl", hash = "sha256:40124b6f27a4c42ac7f06b385e23a9dcd03d84801e9c7130b59b3729a554b1f9"},
 ]
 nbclient = [
-    {file = "nbclient-0.5.1-py3-none-any.whl", hash = "sha256:4d6b116187c795c99b9dba13d46e764d596574b14c296d60670c8dfe454db364"},
-    {file = "nbclient-0.5.1.tar.gz", hash = "sha256:01e2d726d16eaf2cde6db74a87e2451453547e8832d142f73f72fddcd4fe0250"},
+    {file = "nbclient-0.5.4-py3-none-any.whl", hash = "sha256:95a300c6fbe73721736cf13972a46d8d666f78794b832866ed7197a504269e11"},
+    {file = "nbclient-0.5.4.tar.gz", hash = "sha256:6c8ad36a28edad4562580847f9f1636fe5316a51a323ed85a24a4ad37d4aefce"},
 ]
 nbconvert = [
     {file = "nbconvert-6.0.7-py3-none-any.whl", hash = "sha256:39e9f977920b203baea0be67eea59f7b37a761caa542abe80f5897ce3cf6311d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1195,6 +1195,21 @@ fixture = ["fixtures"]
 test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
 
 [[package]]
+name = "requests-ratelimiter"
+version = "0.2.0"
+description = "Rate-limiting for the requests library"
+category = "main"
+optional = false
+python-versions = ">=3.6.2,<4.0.0"
+
+[package.dependencies]
+pyrate-limiter = ">=2.3,<3.0"
+requests = ">=2.20,<3.0"
+
+[package.extras]
+docs = ["furo (==2021.8.17b43)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx (>=4.0.2,<5.0.0)", "sphinx-autodoc-typehints (>=1.11,<2.0)", "sphinx-copybutton (>=0.3,<0.5)"]
+
+[[package]]
 name = "rich"
 version = "10.9.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -1614,7 +1629,7 @@ docs = ["furo", "ipython", "linkify-it-py", "myst-parser", "nbsphinx", "sphinx",
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "303ce9cee3448db758a02d902a811b8e8ef79bbc244f148c2a82842ae2bb5f97"
+content-hash = "41c6891c97aab40f298b7391a08583b0a93a0109e0c552acfe5d53c58429d352"
 
 [metadata.files]
 alabaster = [
@@ -2239,6 +2254,10 @@ requests-cache = [
 requests-mock = [
     {file = "requests-mock-1.9.3.tar.gz", hash = "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"},
     {file = "requests_mock-1.9.3-py2.py3-none-any.whl", hash = "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970"},
+]
+requests-ratelimiter = [
+    {file = "requests-ratelimiter-0.2.0.tar.gz", hash = "sha256:5b9339d9cfa86a9d4b295a122411b8eaedea50f846fced47f6403145dfa0db5e"},
+    {file = "requests_ratelimiter-0.2.0-py3-none-any.whl", hash = "sha256:3f096ccd498f9b99f5115eeb6b81c25e59fccb0ae7744c502dd8e0191b3f5345"},
 ]
 rich = [
     {file = "rich-10.9.0-py3-none-any.whl", hash = "sha256:2c84d9b3459c16bf413fe0f9644c7ae1791971e0bb944dfae56e7c7634b187ab"},

--- a/pyinaturalist/__init__.py
+++ b/pyinaturalist/__init__.py
@@ -5,7 +5,7 @@ user_agent = DEFAULT_USER_AGENT
 
 # Ignore ImportErrors if this is imported outside a virtualenv
 try:
-    from pyinaturalist.api_requests import get_limiter
+    from pyinaturalist.api_requests import get_session
     from pyinaturalist.auth import get_access_token
     from pyinaturalist.client import iNatClient
     from pyinaturalist.constants import *

--- a/pyinaturalist/docs/signatures.py
+++ b/pyinaturalist/docs/signatures.py
@@ -5,7 +5,6 @@ from logging import getLogger
 from typing import Callable, Dict, Iterable, List, Type
 
 import forge
-from pyrate_limiter import Limiter
 from requests import Session
 
 from pyinaturalist.constants import TemplateFunction
@@ -13,7 +12,7 @@ from pyinaturalist.converters import ensure_list
 from pyinaturalist.docs import copy_annotations, copy_docstrings
 
 AUTOMETHOD_INIT = '.. automethod:: __init__'
-COMMON_PARAMS = ['dry_run', 'limiter', 'user_agent', 'session']
+COMMON_PARAMS = ['dry_run', 'user_agent', 'session']
 logger = getLogger(__name__)
 
 
@@ -62,7 +61,7 @@ def copy_doc_signature(
         exclude_args: Arguments to exclude from the new docstring
     """
     if add_common_args:
-        template_functions += (_dry_run, _limiter, _session, _user_agent)
+        template_functions += (_dry_run, _session, _user_agent)
 
     def wrapper(func):
         try:
@@ -89,7 +88,7 @@ document_controller_params = partial(
 
 def document_common_args(func):
     """Just add common args to a function's docstring without modifying the signature"""
-    template_functions = (_dry_run, _limiter, _session, _user_agent)
+    template_functions = (_dry_run, _session, _user_agent)
     func = copy_annotations(func, template_functions)
     func = copy_docstrings(func, template_functions)
     return func
@@ -173,12 +172,6 @@ def deduplicate_var_kwargs(params: Dict) -> Dict:
 def _dry_run(dry_run: bool = False):
     """Args:
     dry_run: Just log the request instead of sending a real request
-    """
-
-
-def _limiter(limiter: Limiter = None):
-    """Args:
-    limiter: Custom rate limits to apply to this request
     """
 
 

--- a/pyinaturalist/request_params.py
+++ b/pyinaturalist/request_params.py
@@ -25,7 +25,7 @@ from pyinaturalist.converters import (
     try_int,
 )
 
-COMMON_PARAMS = ['access_token', 'dry_run', 'limiter', 'user_agent', 'session']
+COMMON_PARAMS = ['access_token', 'dry_run', 'user_agent', 'session']
 MULTIPLE_CHOICE_ERROR_MSG = (
     'Parameter "{}" must have one of the following values: {}\n\tValue provided: {}'
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.2"
 appdirs = ">=1.4.4"
 attrs = ">=21.2.0"
 keyring = ">=22.3"
@@ -60,9 +60,9 @@ docs = ["furo", "ipython", "linkify-it-py", "myst-parser", "nbsphinx", "sphinx",
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.910"
-nox = {version = "^2021.6.12", python = "^3.6.2"}
-nox-poetry = {version = "^0.8.6", python = "^3.6.2"}
-pre-commit = {version = "^2.12", python = "^3.6.2"}
+nox = "^2021.6.12"
+nox-poetry = "^0.8.6"
+pre-commit = "^2.12"
 pretty-errors = "^1.2.23"
 pytest = "^6.2"
 pytest-cov = ">=2.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,14 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-appdirs = ">=1.4.4"
-attrs = ">=21.2.0"
+appdirs = ">=1.4"
+attrs = ">=21.2"
 keyring = ">=22.3"
-pyrate-limiter = ">=2.3.3"
 python-dateutil = ">=2.0"
-python-forge = ">=18.6.0"
+python-forge = ">=18.6"
 requests = ">=2.20"
 requests-cache = "^0.7.4"
+requests-ratelimiter = ">=0.2"
 rich = ">=10.0"
 
 # Documentation dependencies needed for Readthedocs builds (rtd doesn't support poetry.dev-dependencies)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,15 +45,8 @@ enable_logging('DEBUG')
 
 @pytest.fixture(scope='function', autouse=True)
 def patch_cached_session():
-    """Disable request caching during test session"""
+    """Disable request caching and rate-limiting during test session"""
     with patch('pyinaturalist.api_requests.get_session', return_value=Session()):
-        yield
-
-
-@pytest.fixture(scope='function', autouse=True)
-def patch_ratelimit():
-    """Disable rate-limiting during test session"""
-    with patch('pyinaturalist.api_requests.RATE_LIMITER'):
         yield
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -8,20 +8,16 @@ from pyinaturalist.client import iNatClient
 from pyinaturalist.constants import MAX_RETRIES, TOKEN_EXPIRATION
 from pyinaturalist.docs import document_common_args
 
-mock_limiter_1 = MagicMock()
 mock_session_1 = MagicMock()
-mock_limiter_2 = MagicMock()
 mock_session_2 = MagicMock()
 
 SETTINGS_1 = {
     'dry_run': True,
-    'limiter': mock_limiter_1,
     'session': mock_session_1,
     'user_agent': 'pytest',
 }
 SETTINGS_2 = {
     'dry_run': False,
-    'limiter': mock_limiter_2,
     'session': mock_session_2,
     'user_agent': 'python/requests',
 }


### PR DESCRIPTION
Use requests-ratelimiter to store pyrate-limiter settings on the session instead of a separate 'limiter' argument
