### PR TITLE
Pagination improvements

### DIFF
--- a/pyinaturalist/docs/signatures.py
+++ b/pyinaturalist/docs/signatures.py
@@ -12,7 +12,8 @@ from pyinaturalist.converters import ensure_list
 from pyinaturalist.docs import copy_annotations, copy_docstrings
 
 AUTOMETHOD_INIT = '.. automethod:: __init__'
-COMMON_PARAMS = ['dry_run', 'session']
+CONTROLLER_EXCLUDE_PARAMS = ['dry_run', 'session', 'page', 'per_page', 'order', 'count_only']
+
 logger = getLogger(__name__)
 
 
@@ -82,7 +83,7 @@ document_controller_params = partial(
     copy_doc_signature,
     include_sections=['Description', 'Args'],
     include_return_annotation=False,
-    exclude_args=COMMON_PARAMS,
+    exclude_args=CONTROLLER_EXCLUDE_PARAMS,
 )
 
 

--- a/pyinaturalist/paginator.py
+++ b/pyinaturalist/paginator.py
@@ -1,5 +1,4 @@
 from concurrent.futures import ThreadPoolExecutor
-from functools import wraps
 from logging import getLogger
 from math import ceil
 from typing import AsyncIterable, AsyncIterator, Callable, Generic, Iterable, Iterator, List
@@ -110,7 +109,7 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
         if self.limit and self.results_fetched + self.per_page > self.limit:
             self.per_page = self.limit - self.results_fetched
 
-        # Fetch results
+        # Fetch results; handle response object or dict
         response = self.request_function(*self.request_args, **self.kwargs, per_page=self.per_page)
         if isinstance(response, Response):
             response = response.json()
@@ -180,23 +179,6 @@ class JsonPaginator(Paginator):
             'results': results,
             'total_results': len(results),
         }
-
-
-def add_paginate_all(method: str = 'page'):
-    """Decorator that adds an option ``page='all'`` to get all pages of results for the wrapped API
-    request function.
-    """
-
-    def decorator(request_function: Callable):
-        @wraps(request_function)
-        def wrapper(*args, **kwargs):
-            if kwargs.get('page') == 'all':
-                return paginate_all(request_function, *args, method=method, **kwargs)
-            return request_function(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 def paginate_all(request_function: Callable, *args, method: str = 'page', **kwargs) -> JsonResponse:

--- a/pyinaturalist/paginator.py
+++ b/pyinaturalist/paginator.py
@@ -115,7 +115,10 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
         if isinstance(response, Response):
             response = response.json()
         results = response.get('results', response)
-        self._total_results = response.get('total_results', 0)
+
+        # Note: For id-based pagination, only the first page's 'total_results' is accurate
+        if self._total_results == -1:
+            self._total_results = response.get('total_results', 0)
         self.results_fetched += len(results)
 
         # Set params for next request, if there are more results
@@ -157,7 +160,7 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
 
     def __str__(self) -> str:
         return (
-            f'Paginator({self.request_function.__name__}, '
+            f'{self.__class__.__name__}({self.request_function.__name__}, '
             f'fetched={self.results_fetched}/{self.total_results})'
         )
 

--- a/pyinaturalist/v0/observations.py
+++ b/pyinaturalist/v0/observations.py
@@ -12,7 +12,6 @@ from pyinaturalist.converters import convert_all_coordinates, convert_all_timest
 from pyinaturalist.docs import document_request_params
 from pyinaturalist.docs import templates as docs
 from pyinaturalist.exceptions import ObservationNotFound
-from pyinaturalist.paginator import add_paginate_all
 from pyinaturalist.request_params import convert_observation_params, validate_multiple_choice_param
 from pyinaturalist.session import delete, get, post, put
 
@@ -25,7 +24,6 @@ logger = getLogger(__name__)
     docs._bounding_box,
     docs._pagination,
 )
-@add_paginate_all()
 def get_observations(**params) -> Union[List, str]:
     """Get observation data, optionally in an alternative format
 

--- a/pyinaturalist/v1/identifications.py
+++ b/pyinaturalist/v1/identifications.py
@@ -2,7 +2,7 @@ from pyinaturalist.constants import JsonResponse, MultiInt
 from pyinaturalist.converters import convert_all_timestamps
 from pyinaturalist.docs import document_request_params
 from pyinaturalist.docs import templates as docs
-from pyinaturalist.paginator import add_paginate_all
+from pyinaturalist.paginator import paginate_all
 from pyinaturalist.request_params import convert_rank_range
 from pyinaturalist.v1 import get_v1
 
@@ -35,7 +35,6 @@ def get_identifications_by_id(identification_id: MultiInt, **params) -> JsonResp
 
 
 @document_request_params(docs._identification_params, docs._pagination, docs._only_id)
-@add_paginate_all()
 def get_identifications(**params) -> JsonResponse:
     """Search identifications
 
@@ -62,7 +61,10 @@ def get_identifications(**params) -> JsonResponse:
         Response dict containing identification records
     """
     params = convert_rank_range(params)
-    response = get_v1('identifications', **params)
-    identifications = response.json()
+    if params.get('page') == 'all':
+        identifications = paginate_all(get_v1, 'identifications', **params)
+    else:
+        identifications = get_v1('identifications', **params).json()
+
     identifications['results'] = convert_all_timestamps(identifications['results'])
     return identifications

--- a/pyinaturalist/v1/projects.py
+++ b/pyinaturalist/v1/projects.py
@@ -2,13 +2,12 @@ from pyinaturalist.constants import PROJECT_ORDER_BY_PROPERTIES, JsonResponse, M
 from pyinaturalist.converters import convert_all_coordinates, convert_all_timestamps
 from pyinaturalist.docs import document_request_params
 from pyinaturalist.docs import templates as docs
-from pyinaturalist.paginator import add_paginate_all
+from pyinaturalist.paginator import paginate_all
 from pyinaturalist.request_params import validate_multiple_choice_param
 from pyinaturalist.v1 import delete_v1, get_v1, post_v1
 
 
 @document_request_params(docs._projects_params, docs._pagination)
-@add_paginate_all()
 def get_projects(**params) -> JsonResponse:
     """Search projects
 
@@ -44,9 +43,11 @@ def get_projects(**params) -> JsonResponse:
         Response dict containing project records
     """
     validate_multiple_choice_param(params, 'order_by', PROJECT_ORDER_BY_PROPERTIES)
-    response = get_v1('projects', **params)
+    if params.get('page') == 'all':
+        projects = paginate_all(get_v1, 'projects', **params)
+    else:
+        projects = get_v1('projects', **params).json()
 
-    projects = response.json()
     projects['results'] = convert_all_coordinates(projects['results'])
     projects['results'] = convert_all_timestamps(projects['results'])
     return projects

--- a/pyinaturalist/v1/taxa.py
+++ b/pyinaturalist/v1/taxa.py
@@ -2,13 +2,12 @@ from pyinaturalist.constants import JsonResponse, MultiInt
 from pyinaturalist.converters import convert_all_timestamps
 from pyinaturalist.docs import document_request_params
 from pyinaturalist.docs import templates as docs
-from pyinaturalist.paginator import add_paginate_all
+from pyinaturalist.paginator import paginate_all
 from pyinaturalist.request_params import convert_rank_range
 from pyinaturalist.v1 import get_v1
 
 
 @document_request_params(docs._taxon_params, docs._taxon_id_params, docs._pagination)
-@add_paginate_all()
 def get_taxa(**params) -> JsonResponse:
     """Search taxa
 
@@ -34,8 +33,11 @@ def get_taxa(**params) -> JsonResponse:
         Response dict containing taxon records
     """
     params = convert_rank_range(params)
-    response = get_v1('taxa', **params)
-    taxa = response.json()
+    if params.get('page') == 'all':
+        taxa = paginate_all(get_v1, 'taxa', **params)
+    else:
+        taxa = get_v1('taxa', **params).json()
+
     taxa['results'] = convert_all_timestamps(taxa['results'])
     return taxa
 

--- a/test/test_paginator.py
+++ b/test/test_paginator.py
@@ -50,12 +50,13 @@ async def test_async_iter(requests_mock):
     assert len(observations) == 2
 
 
-def test_total_results_count(requests_mock):
+def test_count(requests_mock):
     requests_mock.get(
         f'{API_V1_BASE_URL}/observations?per_page=0', json={'results': [], 'total_results': 50}
     )
 
     paginator = Paginator(get_observations, Observation, q='asdf')
+    assert paginator.count() == 50
     assert paginator.total_results == 50
 
 
@@ -71,4 +72,7 @@ def test_str():
 
     paginator = Paginator(get_observations, Observation)
     assert 'get_observations' in str(paginator)
-    assert '0/0' in str(paginator)
+    assert '0/unknown' in str(paginator)
+
+    paginator.total_results = 50
+    assert '0/50' in str(paginator)

--- a/test/test_paginator.py
+++ b/test/test_paginator.py
@@ -57,7 +57,9 @@ def test_count(requests_mock):
 
     paginator = Paginator(get_observations, Observation, q='asdf')
     assert paginator.count() == 50
-    assert paginator.total_results == 50
+
+    # Subsequent calls should use the previously saved value
+    assert paginator.count() == paginator.total_results == 50
 
 
 def test_next_page__exhausted():

--- a/test/v0/test_observation_fields_v0.py
+++ b/test/v0/test_observation_fields_v0.py
@@ -10,7 +10,7 @@ from test.sample_data import SAMPLE_DATA
 def test_get_observation_fields(requests_mock):
     """get_observation_fields() work as expected (basic use)"""
     requests_mock.get(
-        f'{API_V0_BASE_URL}/observation_fields.json?q=sex&page=2',
+        f'{API_V0_BASE_URL}/observation_fields.json?q=sex',
         json=SAMPLE_DATA['get_observation_fields_page2'],
         status_code=200,
     )


### PR DESCRIPTION
Updates #276

- Exclude most pagination params from controller method signatures, in favor of using `Paginator` instead
- Update `Paginator` to support request positional args
- Fix ID-based pagination; `total_results` is only accurate for first page, since subsequent pages have decreasing `total_results` due to `id_above` param
- Move `paginate_autocomplete()` to `places` module, since that's the only place it's used
- Handle special pagination for `get_observation_fields()` within that function instead of trying to handle it generically in Paginator
- Remove `paginate_all()` support for V0 observations.json
- Update remaining API request functions to call `paginate_all()` instead of (harder to follow) `@add_paginate_all` decorator
- Move request estimating to separate `Paginator.count()` method instead of automagically doing it with `total_results` property