### PR TITLE
Fix a variety of project endpoint issues, and support adding users to project observation rules

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,10 +4,14 @@
 [See all Issues & PRs for 0.17](https://github.com/niconoe/pyinaturalist/milestone/8?closed=1)
 
 ### New Endpoints
-* Added new **Project** endpoint: `update_project()`
+* Added new **Project** endpoint and helper functions:
+  * `update_project()`
+  * `add_project_users()`
+  * `delete_project_users()`
 
 ### Modified Endpoints
-* Allowed string values for `project_id` in `get_projects_by_id()` (e.g., a URL slug instead of a numeric ID)
+* Updated `get_projects_by_id()` to allow string values (URL slugs) for `project_id`
+* Updated `get_user_by_id()` to allow string values (usernames) for `user_id`
 
 ### Other Changes
 * Dropped support for python 3.6

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -48,6 +48,7 @@ For all available endpoints, see: <http://api.inaturalist.org/v1/docs/>
 | GET    | /posts                             | {py:func}`.get_posts`
 | GET    | /projects                          | {py:func}`.get_projects`
 | GET    | /projects/{id}                     | {py:func}`.get_projects_by_id`
+| PUT    | /projects/{id}                     | {py:func}`.update_project`
 | GET    | /projects/{id}/members             |
 | GET    | /projects/{id}/subscriptions       |
 | POST   | /projects/{id}/add                 | {py:func}`.add_project_observation`

--- a/pyinaturalist/auth.py
+++ b/pyinaturalist/auth.py
@@ -12,6 +12,7 @@ from pyinaturalist.session import get_local_session
 logger = getLogger(__name__)
 
 
+# TODO: Don't fetch OAuth token if JWT is cached
 def get_access_token(
     username: str = None,
     password: str = None,

--- a/pyinaturalist/converters.py
+++ b/pyinaturalist/converters.py
@@ -90,7 +90,7 @@ def convert_histogram(response: JsonResponse) -> HistogramResponse:
 
 def convert_csv_list(obj: Any) -> str:
     """Convert list parameters into an API-compatible (comma-delimited) string"""
-    if isinstance(obj, list):
+    if isinstance(obj, list) or isinstance(obj, tuple):
         return ','.join(map(str, obj))
     else:
         return obj

--- a/pyinaturalist/docs/templates.py
+++ b/pyinaturalist/docs/templates.py
@@ -512,7 +512,6 @@ def _project_update_params(
     user_id: int = None,
     admin_attributes: List[Dict] = None,
     project_observation_rules_attributes: List[Dict] = None,
-    remove_users: MultiInt = None,
 ):
     """Args:
     project_id: Numeric project ID or slug (the short name shown in project URL)
@@ -541,7 +540,6 @@ def _project_update_params(
     user_id: User ID of project owner
     admin_attributes: Admin users and their roles
     project_observation_rules_attributes: Rules for observations to include in the project
-    remove_users: One or more user IDs to remove from project observation rules.
     """
 
 

--- a/pyinaturalist/session.py
+++ b/pyinaturalist/session.py
@@ -159,6 +159,7 @@ def request(
     method: str,
     url: str,
     access_token: str = None,
+    allow_str_ids: bool = False,
     dry_run: bool = False,
     expire_after: ExpirationTime = None,
     files: FileOrPath = None,
@@ -196,6 +197,7 @@ def request(
         method=method,
         url=url,
         access_token=access_token,
+        allow_str_ids=allow_str_ids,
         files=files,
         headers=headers,
         ids=ids,
@@ -229,13 +231,13 @@ def prepare_request(
     ids: MultiInt = None,
     json: Dict = None,
     params: RequestParams = None,
-    only_int_ids: bool = True,
+    allow_str_ids: bool = False,
     **kwargs,
 ) -> PreparedRequest:
     """Translate ``pyinaturalist``-specific options into standard request arguments"""
     # Prepare request params and URL
     params = preprocess_request_params(params)
-    url = convert_url_ids(url, ids, only_int_ids)
+    url = convert_url_ids(url, ids, allow_str_ids)
 
     # Set auth header
     headers = headers or {}

--- a/pyinaturalist/v1/__init__.py
+++ b/pyinaturalist/v1/__init__.py
@@ -53,7 +53,9 @@ from pyinaturalist.v1.places import get_places_autocomplete, get_places_by_id, g
 from pyinaturalist.v1.posts import get_posts
 from pyinaturalist.v1.projects import (
     add_project_observation,
+    add_project_users,
     delete_project_observation,
+    delete_project_users,
     get_projects,
     get_projects_by_id,
     update_project,

--- a/pyinaturalist/v1/projects.py
+++ b/pyinaturalist/v1/projects.py
@@ -1,4 +1,4 @@
-from pyinaturalist.constants import PROJECT_ORDER_BY_PROPERTIES, JsonResponse, MultiInt
+from pyinaturalist.constants import PROJECT_ORDER_BY_PROPERTIES, IntOrStr, JsonResponse, MultiInt
 from pyinaturalist.converters import convert_all_coordinates, convert_all_timestamps, ensure_list
 from pyinaturalist.docs import document_request_params
 from pyinaturalist.docs import templates as docs
@@ -122,6 +122,27 @@ def add_project_observation(
     return response.json()
 
 
+def add_project_users(project_id: IntOrStr, user_ids: MultiInt, **params):
+    """Add users to project observation rules
+
+    .. rubric:: Notes
+
+    * :fa:`lock` :ref:`Requires authentication <auth>`
+    * This only affects observation rules, **not** project membership
+
+    Args:
+        project_id: Either numeric project ID or URL slug
+        user_ids: One or more user IDs to add. Only accepts numeric IDs.
+    """
+    rules = _get_project_rules(project_id)
+    for user_id in ensure_list(user_ids):
+        rules.append(
+            {'operand_id': user_id, 'operand_type': 'User', 'operator': 'observed_by_user?'}
+        )
+
+    return update_project(project_id, project_observation_rules_attributes=rules, **params)
+
+
 # TODO: This may not yet be working as intended
 @document_request_params(docs._project_observation_params)
 def delete_project_observation(
@@ -155,9 +176,30 @@ def delete_project_observation(
     # )
 
 
+def delete_project_users(project_id: IntOrStr, user_ids: MultiInt, **params):
+    """Remove users from project observation rules
+
+    .. rubric:: Notes
+
+    * :fa:`lock` :ref:`Requires authentication <auth>`
+    * This only affects observation rules, **not** project membership
+
+    Args:
+        project_id: Either numeric project ID or URL slug
+        user_ids: One or more user IDs to remove. Only accepts numeric IDs.
+    """
+    rules = _get_project_rules(project_id)
+    str_user_ids = [str(user_id) for user_id in ensure_list(user_ids)]
+    for rule in rules:
+        if rule['operand_type'] == 'User' and str(rule['operand_id']) in str_user_ids:
+            rule['_destroy'] = True
+
+    return update_project(project_id, project_observation_rules_attributes=rules, **params)
+
+
 # TODO: Support image uploads for `cover` and `icon`
 @document_request_params(docs._project_update_params)
-def update_project(project_id, **params):
+def update_project(project_id: IntOrStr, **params):
     """Update a project
 
     .. rubric:: Notes
@@ -192,22 +234,6 @@ def update_project(project_id, **params):
     params, kwargs = split_common_params(params)
     kwargs['timeout'] = kwargs.get('timeout') or 60  # This endpoint can be a bit slow
 
-    # Remove any specified users from project observation rules by setting _destroy flag
-    remove_users = _str_ids(params.get('remove_users'))
-    if remove_users:
-        rules = _get_project_rules(project_id)
-        for rule in rules:
-            if rule['operand_type'] == 'User' and str(rule['operand_id']) in remove_users:
-                rule['_destroy'] = True
-        params['project_observation_rules_attributes'] = rules
-
-    add_users = _str_ids(params.get('add_users'))
-    if add_users:
-        rules = _get_project_rules(project_id)
-        for user_id in add_users:
-            {'operand_id': user_id, 'operand_type': 'User', 'operator': 'observed_by_user?'}
-        params['project_observation_rules_attributes'] = rules
-
     response = put_v1(
         f'projects/{project_id}',
         json={'project': params},
@@ -216,10 +242,7 @@ def update_project(project_id, **params):
     return response.json()
 
 
+# TODO: bypass cache for this call?
 def _get_project_rules(project_id):
     project = get_projects_by_id(project_id)['results'][0]
     return project.get('project_observation_rules', [])
-
-
-def _str_ids(ids):
-    return [str(user_id) for user_id in ensure_list(ids)]

--- a/pyinaturalist/v1/projects.py
+++ b/pyinaturalist/v1/projects.py
@@ -80,7 +80,7 @@ def get_projects_by_id(project_id: MultiInt, rule_details: bool = None, **params
         Response dict containing project records
     """
     response = get_v1(
-        'projects', ids=project_id, rule_details=rule_details, only_int_ids=False, **params
+        'projects', rule_details=rule_details, ids=project_id, allow_str_ids=True, **params
     )
 
     projects = response.json()
@@ -198,7 +198,7 @@ def update_project(project_id, **params):
         project = get_projects_by_id(project_id)['results'][0]
         rules = project.get('project_observation_rules', [])
         for rule in rules:
-            if rule['operand_type'] == 'User' and str(rule['id']) in remove_users:
+            if rule['operand_type'] == 'User' and str(rule['operand_id']) in remove_users:
                 rule['_destroy'] = True
         params['project_observation_rules_attributes'] = rules
 

--- a/pyinaturalist/v1/users.py
+++ b/pyinaturalist/v1/users.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from pyinaturalist.constants import JsonResponse
+from pyinaturalist.constants import IntOrStr, JsonResponse
 from pyinaturalist.converters import convert_all_timestamps, convert_generic_timestamps
 from pyinaturalist.docs import document_request_params
 from pyinaturalist.docs import templates as docs
@@ -9,7 +9,7 @@ from pyinaturalist.v1 import get_v1
 logger = getLogger(__name__)
 
 
-def get_user_by_id(user_id: int, **params) -> JsonResponse:
+def get_user_by_id(user_id: IntOrStr, **params) -> JsonResponse:
     """Get a user by ID
 
     .. rubric:: Notes
@@ -32,7 +32,7 @@ def get_user_by_id(user_id: int, **params) -> JsonResponse:
     Returns:
         Response dict containing user record
     """
-    response = get_v1('users', ids=user_id, **params)
+    response = get_v1('users', ids=user_id, allow_str_ids=True, **params)
     results = response.json()['results']
     if not results:
         return {}

--- a/test/controllers/test_project_controller.py
+++ b/test/controllers/test_project_controller.py
@@ -25,7 +25,7 @@ def test_from_id(requests_mock):
     assert project.id == project_id
     assert project.location == (48.777404, -122.306929)
     assert project.project_observation_rules == project.obs_rules
-    assert project.obs_rules[0]['id'] == 1234
+    assert project.obs_rules[0]['id'] == 19344
     assert project.search_parameters[0]['field'] == 'quality_grade'
     assert project.user_ids[-1] == 3387092 and len(project.user_ids) == 33
 

--- a/test/sample_data/get_projects.json
+++ b/test/sample_data/get_projects.json
@@ -11,8 +11,8 @@
             "title": "PNW Invasive Plant EDDR",
             "banner_color": "#4551b7",
             "project_observation_rules": [
-                {"operand_id": 555472, "operand_type": "User", "operator":"observed_by_user?", "id": 1234},
-                {"operand_id": 555472, "operand_type": "User", "operator":"observed_by_user?", "id": 5678}
+                {"operand_id": 1234, "operand_type": "User", "operator":"observed_by_user?", "id": 19344},
+                {"operand_id": 5678, "operand_type": "User", "operator":"observed_by_user?", "id": 19344}
             ],
             "site_features": [
                 {"noteworthy": true, "site_id": 1, "featured_at": "2021-03-16T16:41:32.477Z"}

--- a/test/test_request_params.py
+++ b/test/test_request_params.py
@@ -182,9 +182,9 @@ def test_preprocess_request_params(mock_bool, mock_datetime, mock_list, mock_str
 @patch('pyinaturalist.request_params.convert_datetime_params')
 @patch('pyinaturalist.request_params.convert_list_params')
 @patch('pyinaturalist.request_params.strip_empty_values')
-def test_preprocess_request_body(mock_bool, mock_datetime, mock_list, mock_strip):
+def test_preprocess_request_body(mock_bool, mock_list, mock_datetime, mock_strip):
     preprocess_request_body({'id': 1})
-    assert all([mock_bool.called, mock_datetime.called, mock_list.called, mock_strip.called])
+    assert all([mock_bool.called, mock_datetime.called, not mock_list.called, mock_strip.called])
 
 
 def test_validate_multiple_choice_param():

--- a/test/v1/test_projects.py
+++ b/test/v1/test_projects.py
@@ -94,5 +94,5 @@ def test_update_project__remove_users(mock_put, requests_mock):
 
     project_params = mock_put.call_args[1]['json']['project']
     rules = project_params['project_observation_rules_attributes']
-    assert rules[0]['id'] == 1234 and not rules[0].get('_destroy')
-    assert rules[1]['id'] == 5678 and rules[1]['_destroy'] is True
+    assert rules[0]['operand_id'] == 1234 and not rules[0].get('_destroy')
+    assert rules[1]['operand_id'] == 5678 and rules[1]['_destroy'] is True


### PR DESCRIPTION
Follow-up from #347

Add separate `add_project_users()` and `remove_project_users()` functions