### PR TITLE
Add caching to get_access_token()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,10 +13,14 @@
 * Updated `get_projects_by_id()` to allow string values (URL slugs) for `project_id`
 * Updated `get_user_by_id()` to allow string values (usernames) for `user_id`
 
-### Other Changes
-* Dropped support for python 3.6
+### Authentication
 * Added support for JWT authentication, which will now be used by default
   * To get an OAuth access token instead of a JWT, call `get_access_token(jwt=False)`
+* Added caching to `get_access_token()`. JWTs will be stored in the API response cache and reused
+  until they expire.
+
+### Other Changes
+* Dropped support for python 3.6
 * Added support for setting timeout for individual API requests (with `timeout` parameter)
 * Added support for setting cache timeout for individual API requests (with `expire_after` parameter)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -326,7 +326,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.2"
+version = "4.11.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -1154,7 +1154,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "requests-cache"
-version = "0.9.3"
+version = "0.10.0.dev0"
 description = "A transparent persistent cache for the requests library"
 category = "main"
 optional = false
@@ -1642,7 +1642,7 @@ docs = ["furo", "ipython", "linkify-it-py", "myst-parser", "nbsphinx", "sphinx",
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "7e7c0ab35f2b493d15d6b2d8e16739d49c69f9014fc51abf68303f4fea566a96"
+content-hash = "1bcc54ce0c375aa560ee3a9a578501500d72f1a3916a3df01d1fb38be427d3d2"
 
 [metadata.files]
 alabaster = [
@@ -1875,8 +1875,8 @@ imagesize = [
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
-    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
@@ -2284,8 +2284,8 @@ requests = [
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 requests-cache = [
-    {file = "requests-cache-0.9.3.tar.gz", hash = "sha256:b32f8afba2439e1b3e12cba511c8f579271eff827f063210d62f9efa5bed6564"},
-    {file = "requests_cache-0.9.3-py3-none-any.whl", hash = "sha256:d8b32405b2725906aa09810f4796e54cc03029de269381b404c426bae927bada"},
+    {file = "requests-cache-0.10.0dev0.tar.gz", hash = "sha256:fd179fe1a68c31abf933964a7051c9c3911ee73de20e7febbb3415f4ac737ae2"},
+    {file = "requests_cache-0.10.0dev0-py3-none-any.whl", hash = "sha256:7a577296110debe256c832f1884d7eba8917d00181f056504efaa6295090afd8"},
 ]
 requests-mock = [
     {file = "requests-mock-1.9.3.tar.gz", hash = "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"},

--- a/pyinaturalist/session.py
+++ b/pyinaturalist/session.py
@@ -103,7 +103,7 @@ class ClientSession(CacheMixin, LimiterMixin, Session):
             cache_name=cache_file,
             backend='sqlite',
             expire_after=expire_after,
-            ignored_parameters=['access_token'],
+            ignored_parameters=['Authorization', 'access_token'],
             old_data_on_error=True,
             per_second=per_second,
             per_minute=per_minute,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ platformdirs                = ">=2.5"
 python-dateutil             = ">=2.0"
 python-forge                = ">=18.6"
 requests                    = ">=2.22"
-requests-cache              = ">=0.9.3"
+requests-cache              = "0.10.0.dev0"  # Using some unreleased features
 requests-ratelimiter        = ">=0.2.1"
 rich                        = ">=10.9"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,12 +43,21 @@ MOCK_CREDS_OAUTH = {
 enable_logging('DEBUG')
 
 
+class TestSession(Session):
+    """Session subclass that adds additional keyword args to main methods, so it can be used in
+    place of `ClientSession` during tests
+    """
+
+    def request(self, *args, expire_after=None, only_if_cached=None, **kwargs):
+        return super().request(*args, **kwargs)
+
+
 @pytest.fixture(scope='function', autouse=True)
 def patch_cached_session():
     """Use a regular requests.Session to disable request caching and rate-limiting during tests"""
-    with patch('pyinaturalist.session.get_local_session', return_value=Session()), patch(
-        'pyinaturalist.client.ClientSession', Session
-    ):
+    with patch('pyinaturalist.session.get_local_session', return_value=TestSession()), patch(
+        'pyinaturalist.auth.get_local_session', return_value=TestSession()
+    ), patch('pyinaturalist.client.ClientSession', TestSession):
         yield
 
 

--- a/test/controllers/test_project_controller.py
+++ b/test/controllers/test_project_controller.py
@@ -85,4 +85,4 @@ def test_add_observation(get_access_token, requests_mock):
     client = iNatClient()
     observation_ids = 5678, 9012
     client.projects.add_observations(1234, *observation_ids)
-    get_access_token.assert_called_once()
+    get_access_token.assert_called()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,10 +1,8 @@
-from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pyinaturalist.client import iNatClient
-from pyinaturalist.constants import TOKEN_EXPIRATION
 from pyinaturalist.docs import document_common_args
 
 mock_session_1 = MagicMock()
@@ -61,22 +59,3 @@ def test_client_auth(get_access_token):
     assert final_params_1['access_token'] == 'token'
     assert 'access_token' not in final_params_2
     get_access_token.assert_called_once()
-
-
-@patch('pyinaturalist.client.get_access_token', side_effect=['token_1', 'token_2'])
-def test_client_auth_refresh(get_access_token):
-    """An access token should be added to authenticated requests"""
-    client = iNatClient()
-
-    # Get an initial access token
-    assert client.access_token == 'token_1'
-    assert isinstance(client._token_expires, datetime)
-    assert client._is_token_expired() is False
-
-    # Wait for it to expire
-    client._token_expires = datetime.utcnow() - TOKEN_EXPIRATION
-    assert client._is_token_expired() is True
-
-    # Expect a new access token
-    assert client.access_token == 'token_2'
-    assert client._is_token_expired() is False


### PR DESCRIPTION
Closes #236

# Changes
* Cache the JWT response for reuse until it expires
* The access token refresh feature in `iNatClient` is now redundant, so that has been removed.
* Update to latest pre-release version of `requests-cache` for this feature: https://github.com/reclosedev/requests-cache/issues/394

# Notes
* The cache is checked for a valid JWT before making any real HTTP requests
* The OAuth call is not cached
* Generating a new OAuth token will invalidate any previously generated OAuth tokens **and** JWTs
* The JWT will be stored in the API response cache, which is just a local SQLite database. Since this is a temporary token (that lives for <=24 hours), this doesn't seem like a significant security concern.
* This could potentially be undesirable behavior in some cases, for example if running in an environment shared with other applications or users. Here are some possible options for those cases:
    * Set file permissions on the SQLite db file
    * Use one of the [other backends supported by requests-cache](https://requests-cache.readthedocs.io/en/stable/user_guide/backends.html) that has built-in authentication
    * Disable caching just for this function (could add another keyword arg for this)
    * Disable the cache completely