### PR TITLE
Improve model pretty-print output

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 * Updated rate limiting with a SQLite-based backend. This adds persistence for rate limit tracking
   across multiple threads, processes, and/or application restarts. See
   [pyrate-limiter docs](https://github.com/vutran1710/PyrateLimiter#sqlite) for more details.
+* Misc improvements for response pretty-printing
 
 ## 0.16.0 (2022-02-22)
 [See all Issues & PRs for 0.16](https://github.com/niconoe/pyinaturalist/milestone/7?closed=1)

--- a/examples/sample_data.py
+++ b/examples/sample_data.py
@@ -3,6 +3,8 @@
 """Sample response data of every type to experiment with"""
 import sys
 
+from rich import print
+
 from pyinaturalist import PROJECT_DIR, format_table, pprint
 from pyinaturalist.models import *
 
@@ -56,3 +58,4 @@ tables = [
 if __name__ == '__main__':
     for table in tables:
         pprint(table)
+    print(observation)

--- a/pyinaturalist/formatters.py
+++ b/pyinaturalist/formatters.py
@@ -12,9 +12,8 @@ from copy import deepcopy
 from datetime import date, datetime
 from functools import partial
 from logging import basicConfig, getLogger
-from typing import Any, Iterable, List, Type
+from typing import List, Type
 
-from attr import Attribute
 from requests import PreparedRequest
 
 from pyinaturalist.constants import DATETIME_SHORT_FORMAT, ResponseOrResults, ResponseResult
@@ -42,15 +41,16 @@ from pyinaturalist.models import (
     TaxonCount,
     TaxonSummary,
     User,
-    get_lazy_attrs,
 )
 from pyinaturalist.paginator import Paginator
 
 
 def enable_logging(level: str = 'INFO'):
-    """Configure logging to standard output with prettier tracebacks and terminal colors (if supported).
-    Logging can of course be configured however you want using the stdlib ``logging`` module; this is
-    just here for convenience.
+    """Configure logging to standard output with prettier tracebacks, formatting, and terminal
+    colors (if supported).
+
+    If you prefer, logging can be configured with the stdlib ``logging`` module instead; this just
+    provides some convenient defaults.
 
     Args:
         level: Logging level to use
@@ -271,36 +271,10 @@ format_species_counts = partial(_format_model_objects, cls=TaxonCount)
 format_taxa = partial(_format_model_objects, cls=Taxon)
 format_users = partial(_format_model_objects, cls=User)
 
-
-def get_model_fields(obj: Any) -> Iterable[Attribute]:
-    """Modification for rich's pretty-printer (specifically, ``rich.pretty._get_attr_fields``).
-
-    Adds placeholder attributes for lazy-loaded model properties so they get included in the output.
-    This is particularly useful for previewing in Jupyter or another REPL. These nested objects are
-    shown in condensed format so the preview is more readable. Otherwise, some objects]
-    (especially observations) can turn into a huge wall of text several pages long.
-
-    Does not change behavior for anything except :py:class:`.BaseModel` subclasses.
-    """
-
-    def condense_nested_models(obj):
-        tab = '    '
-        if obj and isinstance(obj, list):
-            condensed_objs = f',\n{tab}{tab}'.join([str(o) for o in obj])
-            return f'[\n{tab}{tab}{condensed_objs}\n{tab}]'
-        return str(obj)
-
-    attrs = list(obj.__attrs_attrs__)
-    if isinstance(obj, BaseModel):
-        attrs += get_lazy_attrs(obj, repr=condense_nested_models)
-    return attrs
-
-
-# If rich is installed, update its pretty-printer to include model properties
+# If rich is installed, install pretty-printer
 try:
     from rich import pretty, print
 
-    pretty._get_attr_fields = get_model_fields
     pretty.install()
 except ImportError:
     pass

--- a/pyinaturalist/models/__init__.py
+++ b/pyinaturalist/models/__init__.py
@@ -11,12 +11,7 @@ from attr import define, validators
 from pyinaturalist.constants import JsonResponse, ResponseOrResults
 from pyinaturalist.converters import convert_lat_long, try_datetime
 from pyinaturalist.models.base import BaseModel, BaseModelCollection, T, load_json
-from pyinaturalist.models.lazy_property import (
-    LazyProperty,
-    add_lazy_attrs,
-    get_lazy_attrs,
-    get_lazy_properties,
-)
+from pyinaturalist.models.lazy_property import LazyProperty, add_lazy_attrs, get_lazy_properties
 
 
 # Aliases and minor helper functions used by model classes

--- a/pyinaturalist/models/lazy_property.py
+++ b/pyinaturalist/models/lazy_property.py
@@ -105,11 +105,6 @@ def add_lazy_attrs(cls, fields):
     return list(fields) + [p.get_lazy_attr() for p in lazy_properties]
 
 
-def get_lazy_attrs(obj, **kwargs) -> List[Attribute]:
-    """Get placeholder attributes for lazy-loaded model properties"""
-    return [make_attribute(p, **kwargs) for p in get_lazy_properties(type(obj))]
-
-
 def get_lazy_properties(cls: Type[BaseModel]) -> Dict[str, LazyProperty]:
     return {k: v for k, v in cls.__dict__.items() if isinstance(v, LazyProperty)}
 

--- a/pyinaturalist/models/observation.py
+++ b/pyinaturalist/models/observation.py
@@ -187,12 +187,17 @@ class Observation(BaseModel):
     # Convert observation timestamps prior to __attrs_init__
     def __init__(
         self,
-        created_at_details: Dict = None,
-        observed_on_string: str = None,
-        observed_time_zone: str = None,
-        time_zone_offset: str = None,
+        # created_at_details: Dict = None,
+        # observed_on_string: str = None,
+        # observed_time_zone: str = None,
+        # time_zone_offset: str = None,
         **kwargs,
     ):
+        created_at_details = kwargs.pop('created_at_details', None)
+        observed_on_string = kwargs.pop('observed_on_string', None)
+        observed_time_zone = kwargs.pop('observed_time_zone', None)
+        time_zone_offset = kwargs.pop('time_zone_offset', None)
+
         tz_offset = time_zone_offset
         tz_name = observed_time_zone
         created_date = (created_at_details or {}).get('date')

--- a/test/test_formatters.py
+++ b/test/test_formatters.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F405
 import re
+from io import StringIO
 
 import pytest
 from rich.console import Console
@@ -153,12 +154,10 @@ def test_simplify_observation():
 PRINTED_OBSERVATION = """
 Observation(
     id=16227955,
-    created_at=datetime.datetime(2018, 9, 5, 0, 0, tzinfo=tzoffset('Europe/Paris', 3600)),
+    created_at='2018-09-05 00:00:00+01:00',
     captive=False,
     community_taxon_id=493595,
     description='',
-    faves=[],
-    geoprivacy=None,
     identifications_count=2,
     identifications_most_agree=True,
     identifications_most_disagree=False,
@@ -168,73 +167,53 @@ Observation(
     mappable=True,
     num_identification_agreements=2,
     num_identification_disagreements=0,
-    oauth_application_id=None,
     obscured=False,
-    observed_on=datetime.datetime(2018, 9, 5, 14, 6, tzinfo=tzoffset('Europe/Paris', 3600)),
+    observed_on='2018-09-05 14:06:00+01:00',
     outlinks=[{'source': 'GBIF', 'url': 'http://www.gbif.org/occurrence/1914197587'}],
-    out_of_range=None,
     owners_identification_from_vision=True,
     place_guess='54 rue des Badauds',
     place_ids=[7008, 8657, 14999, 59614, 67952, 80627, 81490, 96372, 96794, 97391, 97582, 108692],
     positional_accuracy=23,
     preferences={'prefers_community_taxon': None},
-    project_ids=[],
-    project_ids_with_curator_id=[],
-    project_ids_without_curator_id=[],
     public_positional_accuracy=23,
     quality_grade='research',
-    quality_metrics=[],
     reviewed_by=[180811, 886482, 1226913],
     site_id=1,
-    sounds=[],
     species_guess='Lixus bardanae',
-    tags=[],
-    updated_at=datetime.datetime(2018, 9, 22, 19, 19, 27, tzinfo=tzoffset(None, 7200)),
+    updated_at='2018-09-22 19:19:27+02:00',
     uri='https://www.inaturalist.org/observations/16227955',
     uuid='6448d03a-7f9a-4099-86aa-ca09a7740b00',
-    votes=[],
-    annotations=[],
     comments=[
-        borisb on Sep 05, 2018: I now see: Bonus species on observation! You ma...,
-        borisb on Sep 05, 2018: suspect L. bardanae - but sits on Solanum (non-...
+        'borisb on Sep 05, 2018: I now see: Bonus species on observation! You ma...',
+        'borisb on Sep 05, 2018: suspect L. bardanae - but sits on Solanum (non-...'
     ],
     identifications=[
-        [34896306] 🪲 Genus: Lixus (improving) added on Sep 05, 2018 by niconoe,
-        [34926789] 🪲 Species: Lixus bardanae (improving) added on Sep 05, 2018 by borisb,
-        [36039221] 🪲 Species: Lixus bardanae (supporting) added on Sep 22, 2018 by jpreudhomme
+        '[34896306] 🪲 Genus: Lixus (improving) added on Sep 05, 2018 by niconoe',
+        '[34926789] 🪲 Species: Lixus bardanae (improving) added on Sep 05, 2018 by borisb',
+        '[36039221] 🪲 Species: Lixus bardanae (supporting) added on Sep 22, 2018 by jpreudhomme'
     ],
-    ofvs=[],
     photos=[
-        [24355315] https://static.inaturalist.org/photos/24355315/original.jpeg?1536150664 (CC-BY, 1445x1057),
-        [24355313] https://static.inaturalist.org/photos/24355313/original.jpeg?1536150659 (CC-BY, 2048x1364)
+        '[24355315] https://static.inaturalist.org/photos/24355315/original.jpeg?1536150664 (CC-BY, 1445x1057)',
+        '[24355313] https://static.inaturalist.org/photos/24355313/original.jpeg?1536150659 (CC-BY, 2048x1364)'
     ],
-    project_observations=[],
-    taxon=[493595] 🪲 Species: Lixus bardanae,
-    user=[886482] niconoe (Nicolas Noé)
+    taxon='[493595] 🪲 Species: Lixus bardanae',
+    user='[886482] niconoe (Nicolas Noé)'
 )
 """
 
 
-def test_get_model_fields():
-    """Ensure that nested model objects are included in get_model_fields() output"""
-    observation = Observation.from_json(j_observation_1)
-    model_fields = get_model_fields(observation)
-
-    n_nested_model_objects = 8
-    n_regular_attrs = len(Observation.__attrs_attrs__)
-    assert len(model_fields) == n_regular_attrs + n_nested_model_objects
-
-
 def test_pretty_print():
     """Test rich.pretty with modifications, via get_model_fields()"""
-    console = Console(force_terminal=False, width=120)
+    console = Console(force_terminal=False, width=120, file=StringIO())
     observation = Observation.from_json(j_observation_1)
 
-    with console.capture() as output:
-        console.print(observation)
-    rendered = output.get()
+    console.print(observation)
+    rendered = console.file.getvalue()
 
     # Don't check for differences in indendtation
     rendered = re.sub(' +', ' ', rendered.strip())
     expected = re.sub(' +', ' ', PRINTED_OBSERVATION.strip())
+
+    # Emoji may not correctly render in CI
+    rendered = rendered.replace(r'\U0001fab2', '🪲')
     assert rendered == expected


### PR DESCRIPTION
* No longer depends on patching internal rich function `rich.pretty._get_attr_fields` (which could potentially break in the future)
* Now implented via `__rich_repr__` method on `BaseModel`
* Stringify datetime objects
* Exclude default values from output