### PR TITLE
Add extra fields for observations with private/obscured coordinates

### DIFF
--- a/pyinaturalist/models/__init__.py
+++ b/pyinaturalist/models/__init__.py
@@ -37,12 +37,12 @@ def is_in(options: Iterable):
     return validators.in_(list(options) + [None])
 
 
-def coordinate_pair(**kwargs):
+def coordinate_pair(doc: str = None, **kwargs):
     """Field containing a pair of coordiantes"""
     return field(
         default=None,
         converter=convert_lat_long,
-        doc='Location in ``(latitude, logitude)`` decimal degrees',
+        doc=doc or 'Location in ``(latitude, logitude)`` decimal degrees',
         **kwargs,
     )
 

--- a/pyinaturalist/models/observation.py
+++ b/pyinaturalist/models/observation.py
@@ -91,15 +91,25 @@ class Observation(BaseModel):
     owners_identification_from_vision: bool = field(
         default=None, doc="Indicates if the owner's ID was selected from computer vision results"
     )
-
     place_guess: str = field(default=None, doc='Place name determined from observation coordinates')
-    place_ids: List[int] = field(factory=list)
+    place_ids: List[int] = field(
+        factory=list, doc='Place IDs associated with the observation coordinates'
+    )
     positional_accuracy: int = field(
         default=None, doc='GPS accuracy in meters (real accuracy, if obscured)'
     )
     preferences: Dict[str, Any] = field(
         factory=dict,
         doc='Any user observation preferences (related to community IDs, coordinate access, etc.)',
+    )
+    private_location: Coordinates = coordinate_pair(
+        doc=':fa:`lock` Private location in ``(latitude, logitude)`` decimal degrees'
+    )
+    private_place_ids: List[int] = field(
+        factory=list, doc=':fa:`lock` Place IDs associated with the private observation coordinates'
+    )
+    private_place_guess: str = field(
+        default=None, doc=':fa:`lock` Place name determined from private observation coordinates'
     )
     project_ids: List[int] = field(factory=list, doc='All associated project IDs')
     project_ids_with_curator_id: List[int] = field(

--- a/test/sample_data/get_observations_node_page1.json
+++ b/test/sample_data/get_observations_node_page1.json
@@ -261,6 +261,7 @@
       "num_identification_disagreements": 0,
       "geoprivacy": null,
       "location": "50.0949055,-104.71929167",
+      "private_location": "50.0949055,-104.71929167",
       "votes": [],
       "spam": false,
       "user": {

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -215,6 +215,7 @@ def test_observation__converters():
     assert isinstance(obs.user, User) and obs.user.id == 2852555
 
     assert obs.location == (50.0949055, -104.71929167)
+    assert obs.private_location == (50.0949055, -104.71929167)
 
 
 def test_observation__empty():


### PR DESCRIPTION
Closes #367

Add the following fields to `Observation` model:
* `private_location`
* `private_place_ids`
* `private_place_guess`