### PR TITLE
Misc model updates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.17.1 (Unreleased)
+* Add Photo.uuid, observation_id, and user_id fields (for compatibility with inaturalist-open-data)
+* Handle errors in ObservationField type conversions
+* If only `Taxon.ancestry` string is provided, split into IDS (`ancestor_ids`)
+
 ## 0.17.0 (2022-05-17)
 [See all Issues & PRs for 0.17](https://github.com/niconoe/pyinaturalist/milestone/8?closed=1)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -259,7 +259,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc5"
+version = "1.0.0rc6"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
@@ -1844,8 +1844,8 @@ entrypoints = [
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0rc5-py3-none-any.whl", hash = "sha256:295a9d7847f9ad08267f47c701a676ec70a64200a360dd49eb513f72209b09f4"},
-    {file = "exceptiongroup-1.0.0rc5.tar.gz", hash = "sha256:665422550b9653acd46e9cd35d933f28c5158ca4c058c53619cfa112915cd69e"},
+    {file = "exceptiongroup-1.0.0rc6-py3-none-any.whl", hash = "sha256:1ce181e67ce038f3a187f003df3e744d653c8e5bae1387e405003cac2c7d0c97"},
+    {file = "exceptiongroup-1.0.0rc6.tar.gz", hash = "sha256:a32d91b08dba53b3c419eb4e5e1d9aae2c9032e0e8004aec9bc7192881a0c422"},
 ]
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},

--- a/pyinaturalist/__init__.py
+++ b/pyinaturalist/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa: F401, F403
 # isort: skip_file
-__version__ = '0.17.0'
+__version__ = '0.17.1'
 
 from pyinaturalist.auth import get_access_token
 from pyinaturalist.client import iNatClient

--- a/pyinaturalist/converters.py
+++ b/pyinaturalist/converters.py
@@ -291,8 +291,15 @@ def ensure_list(
     value: Any, convert_csv: bool = False, delimiter: str = ','
 ) -> MutableSequence[Any]:
     """Convert an object, response, or (optionally) comma-separated string into a list"""
+    # Handle the occacsional stray numpy array that got lost and made its way here
+    try:
+        value = value.tolist()
+    except (AttributeError, TypeError):
+        pass
     if not value:
         return []
+
+    # Handle response results and comma-separated strings
     elif isinstance(value, dict) and 'results' in value:
         value = value['results']
     elif convert_csv and isinstance(value, str) and delimiter in value:

--- a/pyinaturalist/models/observation_field.py
+++ b/pyinaturalist/models/observation_field.py
@@ -87,7 +87,10 @@ class ObservationFieldValue(BaseModel):
     def __attrs_post_init__(self):
         if self.datatype in OFV_DATATYPES and self.value is not None:
             converter = OFV_DATATYPES[self.datatype]
-            self.value = converter(self.value)
+            try:
+                self.value = converter(self.value)
+            except ValueError:
+                self.value = None
 
     @property
     def row(self) -> TableRow:

--- a/pyinaturalist/models/photo.py
+++ b/pyinaturalist/models/photo.py
@@ -149,6 +149,7 @@ class IconPhoto(Photo):
 
     def __attrs_post_init__(self):
         self._url_format = self.url.replace('.png', '-{size}px.png')
+        self.url = self.medium_url
 
     @classmethod
     def from_iconic_taxon(cls, iconic_taxon_name: str):

--- a/pyinaturalist/models/photo.py
+++ b/pyinaturalist/models/photo.py
@@ -32,10 +32,13 @@ class Photo(BaseModel):
         options=ALL_LICENSES,
         doc='Creative Commons license code',
     )
+    observation_id: int = field(default=None, doc='Associated observation ID')
     original_dimensions: Tuple[int, int] = field(
         converter=format_dimensions, default=(0, 0), doc='Dimensions of original image'
     )
     url: str = field(default=None, doc='Image URL; see properties for URLs of specific image sizes')
+    user_id: int = field(default=None, doc='Associated user ID')
+    uuid: str = field(default=None)
     _url_format: str = field(init=False, repr=False, default=None)
 
     # Unused attributes

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -37,6 +37,7 @@ class Taxon(BaseModel):
     include nested ``ancestors``, ``children``, and results from :py:func:`.get_taxa_autocomplete`.
     """
 
+    ancestry: str = field(default=None, doc='Slash-delimited string of ancestor IDs', repr=False)
     ancestor_ids: List[int] = field(
         factory=list, doc='Taxon IDs of ancestors, from highest rank to lowest'
     )
@@ -136,10 +137,16 @@ class Taxon(BaseModel):
     # universal_search_rank: int = field(default=None)
 
     def __attrs_post_init__(self):
+        # Look up iconic taxon name, if only ID is provided
         if not self.iconic_taxon_name:
             self.iconic_taxon_name = ICONIC_TAXA.get(self.iconic_taxon_id, 'Unknown')
+        # If default photo is missing, use iconic taxon icon
         if not self.default_photo:
             self.default_photo = self.icon
+        # If only ancestor string is provided, split into IDs
+        if self.ancestry and not self.ancestor_ids:
+            delimiter = ',' if ',' in self.ancestry else '/'
+            self.ancestor_ids = [int(x) for x in self.ancestry.split(delimiter)]
 
     @classmethod
     def from_sorted_json_list(cls, value: JsonResponse) -> List['Taxon']:
@@ -147,12 +154,6 @@ class Taxon(BaseModel):
         taxa = cls.from_json_list(value)
         taxa.sort(key=_get_rank_name_idx)
         return taxa
-
-    @property
-    def ancestry(self) -> str:
-        """String containing either ancestor names (if available) or IDs"""
-        tokens = [t.name for t in self.ancestors] if self.ancestors else self.ancestor_ids
-        return ' | '.join([str(t) for t in tokens])
 
     @property
     def child_ids(self) -> List[int]:

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -11,6 +11,7 @@ from pyinaturalist.constants import (
     JsonResponse,
     TableRow,
 )
+from pyinaturalist.converters import ensure_list
 from pyinaturalist.docs import EMOJI
 from pyinaturalist.models import (
     BaseModel,
@@ -39,7 +40,9 @@ class Taxon(BaseModel):
 
     ancestry: str = field(default=None, doc='Slash-delimited string of ancestor IDs', repr=False)
     ancestor_ids: List[int] = field(
-        factory=list, doc='Taxon IDs of ancestors, from highest rank to lowest'
+        factory=list,
+        converter=ensure_list,  # Handle arrays when converting from a dataframe
+        doc='Taxon IDs of ancestors, from highest rank to lowest',
     )
     complete_rank: str = field(
         default=None, doc='Complete or "leaf taxon" rank, e.g. species or subspecies'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyinaturalist"
-version = "0.17.0"
+version = "0.17.1"
 description = "iNaturalist API client for python"
 authors = ["Nicolas Noé <nicolas@niconoe.eu>", "Jordan Cook <Jordan.Cook@pioneer.com>"]
 license = "MIT"

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -331,6 +331,11 @@ def test_observation_field_value__converters():
     assert isinstance(ofv.user, User) and ofv.user.id == 2115051
 
 
+def test_observation_field_value__converter_error():
+    ofv = OFV(datatype='numeric', value='one')
+    assert ofv.value is None
+
+
 def test_observation_field_value__taxon():
     ofv = OFV.from_json(j_ofv_2_taxon)
     assert ofv.datatype == 'taxon'

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -516,6 +516,19 @@ def test_taxon__str():
     assert str(taxon_4) == '[0] ❓ unknown taxon'
 
 
+def test_taxon__ancestors_children():
+    taxon = Taxon.from_json(j_taxon_1)
+    parent = taxon.ancestors[0]
+    child = taxon.children[0]
+    assert isinstance(parent, Taxon) and parent.id == 1
+    assert isinstance(child, Taxon) and child.id == 70116
+
+
+def test_taxon__ancestor_ids():
+    taxon = Taxon(ancestry='1/70116/70118')
+    assert taxon.ancestor_ids == [1, 70116, 70118]
+
+
 def test_taxon__all_names():
     taxon = Taxon.from_json(j_taxon_8_all_names)
     assert taxon.names[1] == {
@@ -573,20 +586,16 @@ def test_taxon__listed_taxa():
     assert str(listed_taxon) == '[70118] (native): 0 observations, 0 comments'
 
 
-def test_taxon__children_ancestors():
-    taxon = Taxon.from_json(j_taxon_1)
-    parent = taxon.ancestors[0]
-    child = taxon.children[0]
-    assert isinstance(parent, Taxon) and parent.id == 1
-    assert isinstance(child, Taxon) and child.id == 70116
-
-
 def test_taxon__properties():
     taxon = Taxon.from_json(j_taxon_1)
     assert taxon.url == f'{INAT_BASE_URL}/taxa/70118'
-    assert taxon.ancestry.startswith('Animalia | Arthropoda | Hexapoda | ')
     assert taxon.child_ids == [70116, 70114, 70117, 70115]
     assert isinstance(taxon.parent, Taxon) and taxon.parent.id == 53850
+
+
+def test_taxon_properties__partial():
+    taxon = Taxon.from_json(j_taxon_2_partial)
+    assert taxon.parent is None
 
 
 @pytest.mark.parametrize('taxon_id', ICONIC_TAXA.keys())
@@ -609,12 +618,6 @@ def test_taxon__no_default_photo(taxon_id):
     assert taxon.icon_url is not None
     assert taxon.iconic_taxon_name is not None
     assert photo.url is not None
-
-
-def test_taxon_properties__partial():
-    taxon = Taxon.from_json(j_taxon_2_partial)
-    assert taxon.ancestry.startswith('48460 | 1 | 47120 | ')
-    assert taxon.parent is None
 
 
 def test_taxon__taxonomy():


### PR DESCRIPTION
* Add Photo.uuid, observation_id, and user_id fields (for compatibility with inaturalist-open-data)
* Handle errors in ObservationField type conversions
* If only `Taxon.ancestry` string is provided, split into IDS (`ancestor_ids`)
