### PR TITLE
Fix handling ListedTaxon.list.id (from /taxa) vs list_id (from /observations/taxon_summary)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,12 @@ branch = true
 source = ['pyinaturalist', 'pyinat']
 omit = ['pyinaturalist/docs/model_docs.py']
 
+[tool.coverage.report]
+exclude_lines = [
+    'pragma: no cover',
+    'if TYPE_CHECKING:',
+]
+
 [tool.isort]
 profile = 'black'
 line_length = 100

--- a/test/controllers/test_observation_controller.py
+++ b/test/controllers/test_observation_controller.py
@@ -204,15 +204,11 @@ def test_taxon_summary__with_listed_taxon(requests_mock):
     assert isinstance(results, TaxonSummary)
     assert isinstance(lt, ListedTaxon)
     assert isinstance(lt.place, Place)
+    assert lt.list.id == 2684267
     assert lt.taxon_id == 47219
     assert lt.place.id == 144952
     assert lt.establishment_means == lt.establishment_means_label == 'introduced'
     assert 'western honey bee' in results.wikipedia_summary
-
-    # Test 'list' alias
-    assert lt.list_id == lt.list['id'] == 2684267
-    lt.list = {'id': 111}
-    assert lt.list_id == lt.list['id'] == 111
 
 
 # TODO:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -598,6 +598,8 @@ def test_taxon__listed_taxa():
     listed_taxon = taxon.listed_taxa[0]
     assert isinstance(listed_taxon, ListedTaxon)
     assert listed_taxon.taxon_id == taxon.id
+    assert listed_taxon.list.id == 299
+    assert listed_taxon.list.title == 'United States Check List'
     assert taxon.listed_taxa_count == 4
     assert str(listed_taxon) == (
         'ListedTaxon(id=5577060, taxon_id=70118, place=Place(id=1, location=(0, 0), '


### PR DESCRIPTION
Fixes #391